### PR TITLE
fix: disable extension on kick docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import TwitchPlatform from "./platforms/twitch/twitch.platform.ts";
 		environment: __environment__,
 		platform: platform.getPlatformType(),
 	};
-	await platform.start();
+	if (platform.shouldStart(window.location)) await platform.start();
 })();
 
 function getPlatform() {

--- a/src/platforms/kick/kick.platform.ts
+++ b/src/platforms/kick/kick.platform.ts
@@ -56,4 +56,8 @@ export default class KickPlatform extends Platform<KickModule, KickEvents, KickS
 			// new ChatMessageMenuModule(...dependencies),
 		];
 	}
+
+	shouldStart(location: Location): boolean {
+		return location.hostname !== "docs.kick.com";
+	}
 }

--- a/src/platforms/twitch/twitch.platform.ts
+++ b/src/platforms/twitch/twitch.platform.ts
@@ -70,4 +70,8 @@ export default class TwitchPlatform extends Platform<TwitchModule, TwitchEvents,
 			new ChatMentionSoundModule(...dependencies),
 		];
 	}
+
+	shouldStart(): boolean {
+		return true;
+	}
 }

--- a/src/shared/platform/platform.ts
+++ b/src/shared/platform/platform.ts
@@ -76,4 +76,6 @@ export default abstract class Platform<
 	getPlatformType() {
 		return this.config.type;
 	}
+
+	abstract shouldStart(location: Location): boolean;
 }


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a fix to disable the extension on the Kick documentation site by adding a condition to the platform's start method and implementing a shouldStart method in the KickPlatform class.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant App
    participant Platform
    participant KickPlatform
    participant TwitchPlatform
    
    App->>Platform: shouldStart(location)
    alt Kick Platform
        Platform->>KickPlatform: shouldStart(location)
        KickPlatform-->>Platform: false if docs.kick.com, true otherwise
    else Twitch Platform
        Platform->>TwitchPlatform: shouldStart(location)
        TwitchPlatform-->>Platform: always true
    end
    
    alt shouldStart = true
        Platform->>Platform: start()
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/86/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80>src/index.ts</a></td><td>Added a condition to check if the platform should start based on the current window location.</td></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/86/files#diff-359a3bd0d5fe04c5f1fc4979ed8c8969a66f83627b66599f82da5c740a47e5d9>src/platforms/kick/kick.platform.ts</a></td><td>Implemented the shouldStart method to prevent starting on docs.kick.com.</td></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/86/files#diff-8e2bb8ba4e91fd8d0479499dd058a13c0ec60238494f914848502a9c2b17da0a>src/platforms/twitch/twitch.platform.ts</a></td><td>Added a shouldStart method that always returns true for TwitchPlatform.</td></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/86/files#diff-46b26bfb9b9aa05ec8c04c0cf32bb7646939b691192b2985e9d7faaf3a7b9442>src/shared/platform/platform.ts</a></td><td>Declared an abstract shouldStart method in the Platform class.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


