### PR TITLE
fix: fix chatters in mod view

### DIFF
--- a/src/platforms/twitch/modules/chatters/chatters.module.tsx
+++ b/src/platforms/twitch/modules/chatters/chatters.module.tsx
@@ -146,7 +146,7 @@ export default class ChattersModule extends TwitchModule {
 
 	private async refreshChatters(loginsToUpdate: string[] = []) {
 		await this.commonUtils().waitFor(
-			() => this.getGuestListOrIsDirectPlayer(),
+			() => this.getGuestListOrIsAllowedPage(),
 			async (guestList) => {
 				const uniqueLogins = this.getUniqueLogins(guestList === true ? undefined : guestList);
 
@@ -180,8 +180,12 @@ export default class ChattersModule extends TwitchModule {
 		);
 	}
 
-	private getGuestListOrIsDirectPlayer() {
-		return this.twitchUtils().isDirectTwitchPlayer() || this.twitchUtils().getGuestList();
+	private getGuestListOrIsAllowedPage() {
+		return (
+			this.twitchUtils().isDirectTwitchPlayer() ||
+			this.twitchUtils().isModeratorView() ||
+			this.twitchUtils().getGuestList()
+		);
 	}
 
 	private updateTotalChattersCounter() {

--- a/src/platforms/twitch/twitch.utils.ts
+++ b/src/platforms/twitch/twitch.utils.ts
@@ -28,6 +28,7 @@ export default class TwitchUtils {
 		const elements = url.split("/");
 		let name = elements[1];
 		if (name === "popout" || elements[0].includes("dashboard")) name = elements[2];
+		if (name === "moderator" || elements[0].includes("dashboard")) name = elements[2];
 		if (name.includes("?")) name = name.substring(0, name.indexOf("?"));
 		return name.toLowerCase();
 	}
@@ -40,6 +41,10 @@ export default class TwitchUtils {
 
 	isDirectTwitchPlayer() {
 		return window.location.href.includes("player.twitch.tv");
+	}
+
+	isModeratorView() {
+		return window.location.href.includes("/moderator/");
 	}
 
 	getUserIdBySideElement(element: Element): string | undefined {


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR fixes the chatters in the moderator view by updating the logic to check for moderator access and adjusting the guest list retrieval accordingly.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant CM as Chatters Module
    participant TU as Twitch Utils
    
    CM->>CM: refreshChatters()
    CM->>CM: getGuestListOrIsAllowedPage()
    
    CM->>TU: isDirectTwitchPlayer()
    TU-->>CM: boolean
    
    CM->>TU: isModeratorView()
    Note over TU: New check for /moderator/ URL
    TU-->>CM: boolean
    
    CM->>TU: getGuestList()
    TU-->>CM: guestList
    
    Note over CM: Combines results to determine<br/>if page is allowed to<br/>refresh chatters

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/87/files#diff-cf2680794ffa16dcb24ebb82438166fc9b9fa0de7786f7e850af84be25a7eb9f>src/platforms/twitch/modules/chatters/chatters.module.tsx</a></td><td>Updated the method to check for allowed pages and modified the guest list retrieval logic.</td></tr>
<tr><td><a href=https://github.com/enhancer-app/enhancer/pull/87/files#diff-2c2e88f3f07a8e48c468a5b36f1e247ee038541074b141cc0f64556e28af8ebc>src/platforms/twitch/twitch.utils.ts</a></td><td>Added a new method to check if the current view is the moderator view.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


