### PR TITLE
fix: prevent sponsored cards from having pin button

### DIFF
--- a/src/platforms/twitch/modules/pin-streamer/pin-streamer.module.tsx
+++ b/src/platforms/twitch/modules/pin-streamer/pin-streamer.module.tsx
@@ -73,7 +73,10 @@ export default class PinStreamerModule extends TwitchModule {
 	private createPin(channelWrapper: Element) {
 		if (
 			channelWrapper.querySelector(".pin-streamer-button") ||
-			channelWrapper.querySelector('a[data-test-selector="similarity-channel"]')
+			channelWrapper.querySelector(
+				'a[data-test-selector="similarity-channel"]',
+			) ||
+			channelWrapper.querySelector(".side-nav-card__link--promoted-followed")
 		)
 			return;
 		const channelID = this.twitchUtils().getUserIdBySideElement(channelWrapper);


### PR DESCRIPTION
### Description

Fixes a small bug I encountered that allowed sponsored cards in the followed channels menu to be pinned. This typically only occurred after pinning a different channel in the same session. After doing so, it allowed the sponsored card to be pinned

<img width="219" height="137" alt="image" src="https://github.com/user-attachments/assets/1d5d3359-c295-4f49-9eda-cad87c725fa6" />

<img width="226" height="158" alt="image" src="https://github.com/user-attachments/assets/037819af-cd0a-4a19-9ac3-019643e629ec" />


### Testing

**Twitch**
- [x] BetterTTV (BTTV)
- [x] FrankerFaceZ (FFZ)
- [x] 7TV
- [x] Native Twitch

**Kick**
- [ ] 7TV
- [ ] Nipahtv (NTV)
- [ ] Native Kick

### Related Issues

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate pin buttons from appearing in the Twitch sidebar for certain channel entries, ensuring only a single pin option is shown.
  * Improves UI consistency by avoiding pin button creation when related or promotional links are present, reducing clutter and potential confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->