### PR TITLE
fix: update scroll handling in chat components to use setPaused method

### DIFF
--- a/src/platforms/twitch/twitch.utils.ts
+++ b/src/platforms/twitch/twitch.utils.ts
@@ -187,7 +187,7 @@ export default class TwitchUtils {
 		if (!element) return;
 		const props = this.reactUtils.findReactChildren<ScrollableChatComponent>(
 			this.reactUtils.getReactInstance(element),
-			(n) => n?.stateNode?.props?.scrollToBottom && n?.stateNode?.props?.messagesHash,
+			(n) => n?.stateNode?.props?.setPaused && n?.stateNode?.props?.messagesHash,
 			100,
 		)?.stateNode.props;
 		if (!props) return;
@@ -206,7 +206,8 @@ export default class TwitchUtils {
 		if (sevenTvChat) {
 			sevenTvChat.scrollTop = sevenTvChat.scrollHeight;
 		} else if (nativeChat) {
-			nativeChat.props.scrollToBottom();
+			nativeChat.props.setPaused(true);
+			nativeChat.props.setPaused(false);
 		}
 	}
 

--- a/src/types/platforms/twitch/twitch.utils.types.ts
+++ b/src/types/platforms/twitch/twitch.utils.types.ts
@@ -175,7 +175,7 @@ export type ScrollableChatComponent = {
 		children: HTMLElement[];
 		focusEscape: () => void;
 		messageHash: TwitchChatMessage[];
-		scrollToBottom: () => void;
+		setPaused: (paused: boolean) => void;
 	};
 };
 


### PR DESCRIPTION
### Description

_Briefly explain what this PR does. Is it a bug fix, new feature, or a refactor?_

### Testing

Select all the environments you tested this PR with:

**Twitch**
- [ ] BetterTTV (BTTV)
- [ ] FrankerFaceZ (FFZ)
- [ ] 7TV
- [ ] Native Twitch

**Kick**
- [ ] 7TV
- [ ] Nipahtv (NTV)
- [ ] Native Kick

_Please describe how you tested this change in the selected environments._

### Related Issues

_If this PR addresses an issue, link it here (e.g., `Closes #123`)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Twitch chat scrolling mechanism to use pause control instead of direct scroll-to-bottom functionality for improved reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->