### PR TITLE
fix(twitch): fix media player instance getter for direct players

### DIFF
--- a/src/platforms/twitch/twitch.utils.ts
+++ b/src/platforms/twitch/twitch.utils.ts
@@ -59,19 +59,20 @@ export default class TwitchUtils {
 	}
 
 	getMediaPlayerNode() {
-		if (this.isDirectTwitchPlayer()) {
-			return this.reactUtils.findReactParents<MediaPlayerComponent>(
-				this.reactUtils.getReactInstance(document.querySelector('[data-a-target="player-overlay-click-handler"]')),
-				(n) => !!n.stateNode?.props?.mediaPlayerInstance,
-				200,
-			)?.stateNode;
+		const isDirect = this.isDirectTwitchPlayer();
+		const selector = isDirect ? '[data-a-target="player-overlay-click-handler"]' : ".persistent-player";
+
+		const element = document.querySelector(selector);
+		if (!element) return undefined;
+
+		const reactInstance = this.reactUtils.getReactInstance(element);
+		const predicate = (n: any) => !!n.stateNode?.props?.mediaPlayerInstance;
+
+		if (isDirect) {
+			return this.reactUtils.findReactParents<MediaPlayerComponent>(reactInstance, predicate, 200)?.stateNode;
 		}
 
-		return this.reactUtils.findReactChildren<MediaPlayerComponent>(
-			this.reactUtils.getReactInstance(document.querySelector(".persistent-player")),
-			(n) => !!n.stateNode?.props?.mediaPlayerInstance,
-			200,
-		)?.stateNode;
+		return this.reactUtils.findReactChildren<MediaPlayerComponent>(reactInstance, predicate, 200)?.stateNode;
 	}
 
 	getMediaPlayerInstance(): MediaPlayerInstanceBase | undefined {


### PR DESCRIPTION
### Description

fixes a bug where the `getMediaPlayerNode()` & `getMediaPlayerInstance()` twitch utils do not work when viewing a popout player

### Testing

| Twitch               | Kick            |
|:---------------------|:----------------|
| ✅ BetterTTV (BTTV)   | 🚫 7TV           |
| ✅ FrankerFaceZ (FFZ) | 🚫 Nipahtv (NTV) |
| ✅ 7TV                | 🚫 Native Kick   |
| ✅ Native Twitch      |                 |

### Related Issues

closes #134 