### PR TITLE
chore: add kaedriz and esteeming to contributors

### DIFF
--- a/src/shared/components/settings/about.component.tsx
+++ b/src/shared/components/settings/about.component.tsx
@@ -170,7 +170,7 @@ interface EnhancerAboutComponentProps {
 }
 
 export function EnhancerAboutComponent({ icons }: EnhancerAboutComponentProps) {
-	const contributors = ["igorovh", "czestereq", "d33zor", "kawre", "usermacieg"];
+	const contributors = ["igorovh", "czestereq", "d33zor", "kawre", "usermacieg", "kaedriz", "esteeming"];
 	const testers = [
 		"piotrgamerpl",
 		"m0rtak_",


### PR DESCRIPTION
## Summary

- Added **kaedriz** and **esteeming** to the contributors list in the About settings page (`about.component.tsx`).

## Why

New contributors should be recognized in the extension's settings UI.

## Testing

- Verified the contributors array was updated correctly in `src/shared/components/settings/about.component.tsx`.