### PR TITLE
fix(kick): target channel player for latency

### DIFF
--- a/src/platforms/kick/modules/stream-latency/stream-latency.module.tsx
+++ b/src/platforms/kick/modules/stream-latency/stream-latency.module.tsx
@@ -116,6 +116,6 @@ export default class StreamLatencyModule extends KickModule {
 	}
 
 	private getVideoElement(): HTMLVideoElement | null {
-		return document.querySelector("video");
+		return document.querySelector("video#video-player");
 	}
 }


### PR DESCRIPTION
## Summary
- target the Kick channel player when calculating stream latency
- avoid reporting a playing stream as offline after SPA navigation when another video element is present

## Testing
- `bun run typecheck`
- `npx @biomejs/biome check src/`
- push hook: 17 tests passed