### PR TITLE
fix(worker): prevent extension startup stalls

### DIFF
--- a/src/platforms/twitch/modules/chat-mention-sound/chat-mention-sound.module.tsx
+++ b/src/platforms/twitch/modules/chat-mention-sound/chat-mention-sound.module.tsx
@@ -108,7 +108,7 @@ export default class ChatMentionSoundModule extends TwitchModule {
 	private setCurrentUsername() {
 		const scrollableChat = this.twitchUtils().getScrollableChat()?.props;
 		if (!scrollableChat) return;
-		this.currentUsername = scrollableChat.currentUserLogin.toLowerCase();
+		this.currentUsername = scrollableChat.currentUserLogin?.toLowerCase();
 		this.logger.debug(`Joined chat as ${this.currentUsername}`);
 	}
 

--- a/src/shared/platform/platform.ts
+++ b/src/shared/platform/platform.ts
@@ -36,7 +36,8 @@ export default abstract class Platform<
 
 	async start() {
 		await this.workerApi.start();
-		await Promise.all([this.settingsCache.initialize(), this.initializeEnhancerApi()]);
+		await this.settingsCache.initialize();
+		void this.initializeEnhancerApi();
 		await this.initialize();
 		await this.loadModules();
 		this.logger.info(`Started ${this.config.type} extension`);

--- a/src/shared/worker/enhancer-api/enhancer-api.service.ts
+++ b/src/shared/worker/enhancer-api/enhancer-api.service.ts
@@ -883,7 +883,7 @@ export class EnhancerApiService {
 	}
 
 	private async requestSeeds(topic: EnhancerAggregateTopic): Promise<CachedAggregateSeed[]> {
-		const tabs = await chrome.tabs.query({});
+		const tabs = await chrome.tabs.query({ url: ["*://*.twitch.tv/*", "*://*.kick.com/*"] });
 		const request: WorkerBroadcast = {
 			type: "enhancer-api-seed-request",
 			payload: { requestId: crypto.randomUUID(), topic },

--- a/src/shared/worker/worker.bridge.ts
+++ b/src/shared/worker/worker.bridge.ts
@@ -83,9 +83,14 @@ export default class WorkerBridge {
 						seed: unknown;
 					};
 					if (detail.requestId !== requestId) return;
+					clearTimeout(timeout);
 					this.bridgeElement?.removeEventListener("enhancer-api-seed-response", handleResponse);
 					sendResponse(detail.seed);
 				};
+				const timeout = setTimeout(() => {
+					this.bridgeElement?.removeEventListener("enhancer-api-seed-response", handleResponse);
+					sendResponse(null);
+				}, 2000);
 				this.bridgeElement.addEventListener("enhancer-api-seed-response", handleResponse);
 				this.bridgeElement.dispatchEvent(
 					new CustomEvent<string>("enhancer-api-seed-request", { detail: JSON.stringify(message.payload) }),

--- a/src/shared/worker/worker.service.ts
+++ b/src/shared/worker/worker.service.ts
@@ -32,7 +32,7 @@ export default class WorkerService {
 	async start() {
 		this.setupMessageListener();
 		await this.waitForBridge();
-		await this.ping();
+		void this.ping();
 		this.startPing();
 		this.logger.info("WorkerService started");
 	}


### PR DESCRIPTION
## Summary

- keep bridge readiness and settings initialization in the startup path while making worker ping and Enhancer API initialization non-blocking
- time out unanswered seed requests after two seconds and query seeds only from supported Twitch and Kick tabs
- avoid an exception when mention sounds initialize for an anonymous Twitch user

## Performance validation

- profiled Twitch startup and steady-state execution with Playwright and the Chrome CPU profiler
- measured less than 1% single-core CPU usage from Enhancer during normal operation
- tested without third-party extensions and separately with current 7TV, legacy 7TV, BetterTTV, and FrankerFaceZ
- reproduced an unanswered seed request delaying module startup from about 1-2 seconds to 11.1 seconds
- verified the same scenario loads modules in 2.0 seconds after this change

## Testing

- `bun test` (17 passed, 66 assertions)
- `bun run typecheck`
- `npx @biomejs/biome check src/`
- `bun run build`
- Playwright startup, channel navigation, long-task, event-loop lag, heap, selector, chat observer, and worker seed profiling
