### PR TITLE
fix(chatters): wait for multistream data

### DIFF
--- a/src/platforms/twitch/modules/chatters/chatters.module.tsx
+++ b/src/platforms/twitch/modules/chatters/chatters.module.tsx
@@ -205,11 +205,14 @@ export default class ChattersModule extends TwitchModule {
 	}
 
 	private getLoginsOrIsAllowedPage() {
-		return this.twitchUtils().isDirectTwitchPlayer() || this.twitchUtils().isModeratorView() || this.getLogins();
+		if (this.twitchUtils().isDirectTwitchPlayer() || this.twitchUtils().isModeratorView()) return true;
+		const logins = this.getLogins();
+		return logins?.length ? logins : undefined;
 	}
 
-	private getLogins(): string[] {
+	private getLogins(): string[] | undefined {
 		const streamInfo = this.twitchUtils().getStreamInfo();
+		if (!streamInfo) return;
 		const organizerLogin = streamInfo?.channelLogin;
 		const costreamerLogins = streamInfo?.costreamDetails?.topCostreamers.map((streamer) => streamer.login) ?? [];
 		const guestStarLogins = streamInfo?.guestStarGuests.map((guest) => guest.user.login) ?? [];


### PR DESCRIPTION
## Summary
Fixes the initial chatters count loading for Twitch shared streams.

## Changes
- Waits for Twitch stream metadata before treating the channel list as ready.
- Keeps single-stream behavior unchanged and fetches only the main channel there.
- Fetches guest/costreamer channels automatically when shared-stream data is available.

## Testing
- bun run typecheck
- npx @biomejs/biome check src/
- Push hook: 17 tests passed and TypeScript passed