### PR TITLE
fix(storage): preserve settings across cleanup (#105)

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -8,6 +8,7 @@ export function getManifest(isDevelopment: boolean) {
 		name,
 		description: "Enhancer is open-sourced and free extension, which adds what is missing on streaming platforms.",
 		version: data.version,
+		permissions: ["storage", "unlimitedStorage"],
 		action: {
 			default_icon: "assets/enhancer/logo-128.png",
 		},

--- a/src/shared/worker/settings/settings.database.ts
+++ b/src/shared/worker/settings/settings.database.ts
@@ -2,18 +2,32 @@ import { Database } from "$shared/worker/database/database.ts";
 import type { PlatformType } from "$types/shared/platform.types.ts";
 import type { PlatformSettings, SettingsRecord } from "$types/shared/worker/settings-worker.types.ts";
 
+const STORAGE_KEY_PREFIX = "enhancer.settings";
+
 export class SettingsDatabase extends Database {
 	protected readonly dbName = "enhancer_settings";
 	protected readonly dbVersion = 1;
 	private readonly storeName = "settings";
 
 	private cache = new Map<PlatformType, PlatformSettings>();
+	private indexedDbAvailable = true;
 
 	constructor(private readonly defaults: Map<PlatformType, PlatformSettings>) {
 		super("settings-db");
 	}
 
-	protected onUpgrade(event: IDBVersionChangeEvent, db: IDBDatabase): void {
+	async initialize(): Promise<void> {
+		try {
+			await super.initialize();
+		} catch (error) {
+			this.indexedDbAvailable = false;
+			this.logger.warn("IndexedDB unavailable, using extension storage only:", error);
+		}
+	}
+
+	protected onUpgrade(_event: IDBVersionChangeEvent, db: IDBDatabase): void {
+		if (db.objectStoreNames.contains(this.storeName)) return;
+
 		this.logger.info(`Creating settings database (version ${this.dbVersion})...`);
 		const store = db.createObjectStore(this.storeName, { keyPath: "id" });
 		store.createIndex("by_platform", "platform", { unique: true });
@@ -25,14 +39,22 @@ export class SettingsDatabase extends Database {
 			return this.cache.get(platform) as T;
 		}
 
-		const result = await this.request<SettingsRecord | undefined>(this.storeName, "readonly", (store) =>
-			store.get(platform),
-		);
-
 		const defaultSettings = this.getDefaultSettings(platform);
-		const settings: PlatformSettings = result ? { ...defaultSettings, ...result.settings } : defaultSettings;
+		const storedSettings = await this.getExtensionSettings(platform);
+		if (storedSettings) {
+			const settings: PlatformSettings = { ...defaultSettings, ...storedSettings };
+			this.cache.set(platform, settings);
+			await this.saveIndexedDbSettings(platform, settings);
+			return settings as T;
+		}
+
+		const indexedDbResult = await this.getIndexedDbSettings(platform);
+		const settings: PlatformSettings = indexedDbResult.record
+			? { ...defaultSettings, ...indexedDbResult.record.settings }
+			: defaultSettings;
 
 		this.cache.set(platform, settings);
+		if (indexedDbResult.available) await this.saveExtensionSettings(platform, settings);
 		return settings as T;
 	}
 
@@ -45,9 +67,72 @@ export class SettingsDatabase extends Database {
 			lastUpdate: now,
 		};
 
-		await this.request<void>(this.storeName, "readwrite", (store) => store.put(settingsRecord));
+		const extensionStorageUpdated = await this.saveExtensionSettings(platform, settings);
+		const indexedDbUpdated = await this.saveIndexedDbSettings(platform, settingsRecord.settings);
+		if (!extensionStorageUpdated && !indexedDbUpdated) {
+			throw new Error(`Failed to persist settings for platform: ${platform}`);
+		}
+
 		this.cache.set(platform, settings);
 		this.logger.debug(`Settings updated for platform: ${platform}`);
+	}
+
+	private async getExtensionSettings(platform: PlatformType): Promise<PlatformSettings | undefined> {
+		try {
+			const key = this.getStorageKey(platform);
+			const result = await chrome.storage.local.get(key);
+			const settings = result[key];
+			return isRecord(settings) ? (settings as PlatformSettings) : undefined;
+		} catch (error) {
+			this.logger.warn("Failed to read extension storage:", error);
+			return undefined;
+		}
+	}
+
+	private async saveExtensionSettings(platform: PlatformType, settings: PlatformSettings): Promise<boolean> {
+		try {
+			await chrome.storage.local.set({ [this.getStorageKey(platform)]: settings });
+			return true;
+		} catch (error) {
+			this.logger.warn("Failed to write extension storage:", error);
+			return false;
+		}
+	}
+
+	private async getIndexedDbSettings(platform: PlatformType): Promise<{ available: boolean; record?: SettingsRecord }> {
+		if (!this.indexedDbAvailable) return { available: false };
+
+		try {
+			const record = await this.request<SettingsRecord | undefined>(this.storeName, "readonly", (store) =>
+				store.get(platform),
+			);
+			return { available: true, record };
+		} catch (error) {
+			this.logger.warn("Failed to read IndexedDB settings:", error);
+			return { available: false };
+		}
+	}
+
+	private async saveIndexedDbSettings(platform: PlatformType, settings: PlatformSettings): Promise<boolean> {
+		if (!this.indexedDbAvailable) return false;
+
+		try {
+			const settingsRecord: SettingsRecord = {
+				id: platform,
+				platform,
+				settings,
+				lastUpdate: Date.now(),
+			};
+			await this.request<void>(this.storeName, "readwrite", (store) => store.put(settingsRecord));
+			return true;
+		} catch (error) {
+			this.logger.warn("Failed to write IndexedDB settings:", error);
+			return false;
+		}
+	}
+
+	private getStorageKey(platform: PlatformType): string {
+		return `${STORAGE_KEY_PREFIX}.${platform}`;
 	}
 
 	private getDefaultSettings(platform: PlatformType): PlatformSettings {
@@ -57,4 +142,8 @@ export class SettingsDatabase extends Database {
 		}
 		return defaults;
 	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/test/settings.database.test.ts
+++ b/src/test/settings.database.test.ts
@@ -10,7 +10,7 @@ const originalChrome = globalThis.chrome;
 const originalEnvironment = (globalThis as typeof globalThis & { __environment__?: string }).__environment__;
 
 afterEach(() => {
-	Object.defineProperty(globalThis, "chrome", { configurable: true, value: originalChrome });
+	Object.defineProperty(globalThis, "chrome", { configurable: true, writable: true, value: originalChrome });
 	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: originalEnvironment });
 });
 
@@ -19,6 +19,7 @@ test("keeps settings in extension storage after a worker restart", async () => {
 	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: "test" });
 	Object.defineProperty(globalThis, "chrome", {
 		configurable: true,
+		writable: true,
 		value: {
 			storage: {
 				local: {

--- a/src/test/settings.database.test.ts
+++ b/src/test/settings.database.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, expect, test } from "bun:test";
+import { KICK_DEFAULT_SETTINGS } from "$kick/kick.constants.ts";
+import { SettingsDatabase } from "$shared/worker/settings/settings.database.ts";
+import { TWITCH_DEFAULT_SETTINGS } from "$twitch/twitch.constants.ts";
+import type { TwitchSettings } from "$types/platforms/twitch/twitch.settings.types.ts";
+import type { PlatformSettings } from "$types/shared/worker/settings-worker.types.ts";
+import type { PlatformType } from "$types/shared/worker/worker.types.ts";
+
+const originalChrome = globalThis.chrome;
+const originalEnvironment = (globalThis as typeof globalThis & { __environment__?: string }).__environment__;
+
+afterEach(() => {
+	Object.defineProperty(globalThis, "chrome", { configurable: true, value: originalChrome });
+	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: originalEnvironment });
+});
+
+test("keeps settings in extension storage after a worker restart", async () => {
+	const values = new Map<string, unknown>();
+	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: "test" });
+	Object.defineProperty(globalThis, "chrome", {
+		configurable: true,
+		value: {
+			storage: {
+				local: {
+					get: async (key: string) => ({ [key]: values.get(key) }),
+					set: async (entries: Record<string, unknown>) => {
+						for (const [key, value] of Object.entries(entries)) values.set(key, value);
+					},
+				},
+			},
+		},
+	});
+
+	const defaults = new Map<PlatformType, PlatformSettings>([
+		["twitch", TWITCH_DEFAULT_SETTINGS],
+		["kick", KICK_DEFAULT_SETTINGS],
+	]);
+	const firstDatabase = new SettingsDatabase(defaults);
+	await firstDatabase.initialize();
+	const initialSettings = await firstDatabase.getSettings<TwitchSettings>("twitch");
+	expect(values.has("enhancer.settings.twitch")).toBe(false);
+	await firstDatabase.updateSettings("twitch", { ...initialSettings, pinnedStreamers: ["streamer-1"] });
+
+	const secondDatabase = new SettingsDatabase(defaults);
+	await secondDatabase.initialize();
+	const settingsAfterRestart = await secondDatabase.getSettings<TwitchSettings>("twitch");
+
+	expect(settingsAfterRestart.pinnedStreamers).toEqual(["streamer-1"]);
+});


### PR DESCRIPTION
## Summary

Relates to #105.

Moves platform settings to `chrome.storage.local` with `unlimitedStorage`, while preserving IndexedDB as a fallback and backup. Existing IndexedDB settings are migrated lazily without deleting the original data.

## Changes

- Add cross-browser storage permissions.
- Read and write settings through extension storage.
- Keep IndexedDB intact and synchronize it during the transition.
- Prevent failed IndexedDB reads from being replaced by defaults.
- Add storage persistence coverage.

## Testing

- [x] `bun test`
- [x] `bun run typecheck`
- [x] `npx @biomejs/biome check src/ manifest.config.ts`
- [x] `bun run build`