### PR TITLE
feat(websocket): include extension version

### DIFF
--- a/src/shared/worker/enhancer-api/enhancer-api.service.ts
+++ b/src/shared/worker/enhancer-api/enhancer-api.service.ts
@@ -45,7 +45,10 @@ export class EnhancerApiService {
 	private clientGeneration = 0;
 	private pendingSubscription: SubscriptionState | null = null;
 
-	constructor(private readonly logger: Logger) {
+	constructor(
+		private readonly logger: Logger,
+		private readonly version = "unknown",
+	) {
 		chrome.tabs.onRemoved.addListener((tabId) => this.removeTabClients(tabId));
 	}
 
@@ -274,7 +277,7 @@ export class EnhancerApiService {
 		}
 
 		this.connectionPromise = new Promise<void>((resolve, reject) => {
-			const socket = new WebSocket(EnhancerApiService.WEBSOCKET_URL);
+			const socket = new WebSocket(`${EnhancerApiService.WEBSOCKET_URL}?v=${encodeURIComponent(this.version)}`);
 			this.socket = socket;
 			let settled = false;
 			const timeout = setTimeout(() => {

--- a/src/shared/worker/worker.background.ts
+++ b/src/shared/worker/worker.background.ts
@@ -21,7 +21,7 @@ export default class WorkerBackground {
 	);
 	private readonly watchtimeDatabase = new WatchtimeDatabase();
 	private readonly watchtimeAccumulator = new WatchtimeAccumulator(this.watchtimeDatabase);
-	private readonly enhancerApiService = new EnhancerApiService(this.enhancerApiLogger);
+	private readonly enhancerApiService = new EnhancerApiService(this.enhancerApiLogger, __version__);
 	private readonly handlerRegistry = new HandlerRegistry(
 		this.logger,
 		this.settingsDatabase,

--- a/src/test/enhancer-api.service.test.ts
+++ b/src/test/enhancer-api.service.test.ts
@@ -12,6 +12,7 @@ class FakeWebSocket extends EventTarget {
 	static readonly OPEN = 1;
 	static instance: FakeWebSocket;
 	static instances = 0;
+	static urls: string[] = [];
 	static commands: any[] = [];
 	static onSubscribe: (socket: FakeWebSocket, command: any, topic: string) => void = (socket, _command, topic) => {
 		queueMicrotask(() => socket.receive({ type: "subscription.confirmed", topic }));
@@ -19,10 +20,11 @@ class FakeWebSocket extends EventTarget {
 	};
 	readonly readyState = FakeWebSocket.OPEN;
 
-	constructor(_url: string) {
+	constructor(url: string) {
 		super();
 		FakeWebSocket.instance = this;
 		FakeWebSocket.instances++;
+		FakeWebSocket.urls.push(url);
 		queueMicrotask(() => this.receive({ type: "connection.ready" }));
 	}
 
@@ -46,6 +48,7 @@ class FakeWebSocket extends EventTarget {
 
 	static reset(): void {
 		FakeWebSocket.instances = 0;
+		FakeWebSocket.urls = [];
 		FakeWebSocket.commands = [];
 		FakeWebSocket.onSubscribe = (socket, _command, topic) => {
 			queueMicrotask(() => socket.receive({ type: "subscription.confirmed", topic }));
@@ -114,7 +117,7 @@ test("uses one HTTP snapshot and applies final patches without refetching", asyn
 		return Response.json(aggregate("100-0"));
 	}) as typeof fetch;
 
-	const service = new EnhancerApiService(logger);
+	const service = new EnhancerApiService(logger, "5.1.41");
 	const first = await service.initialize(7, 0, "client-a", "twitch");
 	const second = await service.initialize(8, 0, "client-b", "twitch");
 
@@ -123,6 +126,7 @@ test("uses one HTTP snapshot and applies final patches without refetching", asyn
 	expect(first.cursor).toBe("100-0");
 	expect(second.aggregate.accounts).toHaveLength(1);
 	expect(FakeWebSocket.instances).toBe(1);
+	expect(FakeWebSocket.urls).toEqual(["wss://api.enhancer.at/v1/ws?v=5.1.41"]);
 	expect(FakeWebSocket.commands.find((command) => command.type === "subscribe")?.after).toBe("100-0");
 
 	FakeWebSocket.instance.receive({


### PR DESCRIPTION
## Summary

Pass the extension version to the Enhancer WebSocket connection.

## Changes

- Passes the Vite-injected __version__ from the background worker.
- Adds it as the encoded v query parameter.
- Covers the resulting WebSocket URL in tests.

## Testing

- bun run typecheck
- npx @biomejs/biome check src/
- bun test src/test/enhancer-api.service.test.ts
- Pre-push checks: 18 tests passed.
