### PR TITLE
feat(chat-badges): improve badge tooltips

### DIFF
--- a/src/platforms/kick/modules/chat-badges/chat-badges.module.tsx
+++ b/src/platforms/kick/modules/chat-badges/chat-badges.module.tsx
@@ -42,6 +42,7 @@ export default class ChatBadgesModule extends KickModule {
 
 		for (const badge of userBadges) {
 			const lowestSourceUrl = this.commonUtils().getLowestBadgeSourceUrl(badge.sources);
+			const highestSourceUrl = this.commonUtils().getHighestBadgeSourceUrl(badge.sources);
 			if (!lowestSourceUrl) {
 				this.logger.warn(`Badge ${badge.badgeId} is missing a source url`);
 				continue;
@@ -55,7 +56,24 @@ export default class ChatBadgesModule extends KickModule {
 			badgeWrapper.style.alignItems = "center";
 			badgeWrapper.style.display = "inline-flex";
 			render(
-				<TooltipComponent content={<p>{badge.name}</p>} position="right" delay={200}>
+				<TooltipComponent
+					content={
+						<div style={{ maxWidth: 180, textAlign: "center" }}>
+							{highestSourceUrl && (
+								<img
+									src={highestSourceUrl}
+									alt={badge.name}
+									width={72}
+									height={72}
+									style={{ display: "block", margin: "0 auto" }}
+								/>
+							)}
+							<p style={{ margin: "8px 0 0", overflowWrap: "anywhere" }}>{badge.name}</p>
+						</div>
+					}
+					position="right"
+					delay={200}
+				>
 					<img src={lowestSourceUrl} alt={badge.name} width={size} height={size} style={{ marginRight: ".25em" }} />
 				</TooltipComponent>,
 				badgeWrapper,

--- a/src/platforms/twitch/modules/chat-badges/chat-badges.module.tsx
+++ b/src/platforms/twitch/modules/chat-badges/chat-badges.module.tsx
@@ -37,6 +37,7 @@ export default class ChatBadgesModule extends TwitchModule {
 
 		for (const badge of userBadges) {
 			const lowestSourceUrl = this.commonUtils().getLowestBadgeSourceUrl(badge.sources);
+			const highestSourceUrl = this.commonUtils().getHighestBadgeSourceUrl(badge.sources);
 			if (!lowestSourceUrl) {
 				this.logger.warn(`Badge ${badge.badgeId} is missing a source url`);
 				continue;
@@ -52,7 +53,23 @@ export default class ChatBadgesModule extends TwitchModule {
 				badgeWrapper.style.verticalAlign = "baseline";
 			}
 			render(
-				<TooltipComponent content={<p>{badge.name}</p>} position="right">
+				<TooltipComponent
+					content={
+						<div style={{ maxWidth: 180, textAlign: "center" }}>
+							{highestSourceUrl && (
+								<img
+									src={highestSourceUrl}
+									alt={badge.name}
+									width={72}
+									height={72}
+									style={{ display: "block", margin: "0 auto" }}
+								/>
+							)}
+							<p style={{ margin: "8px 0 0", overflowWrap: "anywhere" }}>{badge.name}</p>
+						</div>
+					}
+					position="right"
+				>
 					<img
 						src={lowestSourceUrl}
 						alt={badge.name}

--- a/src/shared/utils/common.utils.ts
+++ b/src/shared/utils/common.utils.ts
@@ -90,4 +90,10 @@ export default class CommonUtils {
 		entries.sort(([left], [right]) => Number.parseInt(left, 10) - Number.parseInt(right, 10));
 		return entries[0]?.[1] ?? null;
 	}
+
+	getHighestBadgeSourceUrl(sources: Record<string, string>): string | null {
+		const entries = Object.entries(sources);
+		entries.sort(([left], [right]) => Number.parseInt(left, 10) - Number.parseInt(right, 10));
+		return entries.at(-1)?.[1] ?? null;
+	}
 }


### PR DESCRIPTION
## Summary

Improve custom badge tooltips with a larger badge preview.

## Changes

- Select the largest badge image returned by the API.
- Show the image above the badge name for Twitch and Kick.
- Center the name and wrap long names within the tooltip.

## Testing

- `bun run typecheck`
- `npx @biomejs/biome check src/`
- Push hook: 18 tests passed
