### PR TITLE
fix(chatters): detect shared channels automatically

### DIFF
--- a/src/platforms/twitch/modules/chatters/chatters.module.tsx
+++ b/src/platforms/twitch/modules/chatters/chatters.module.tsx
@@ -76,10 +76,14 @@ export default class ChattersModule extends TwitchModule {
 	private chattersCounters: Record<string, Signal<number>> = {};
 
 	private updateInterval: NodeJS.Timeout | undefined;
+	private channelDiscoveryTimer: NodeJS.Timeout | undefined;
 	private lastUpdatedAt = 0;
+	private lastKnownLogins = new Set<string>();
+	private refreshingChatters = false;
 
 	private static INDIVIDUAL_CHATTERS_COMPONENT_WRAPPER_CLASS = "enhancer-chat-counter-wrapper";
 	private static UPDATE_INTERVAL_TIME = 30000;
+	private static CHANNEL_DISCOVERY_INTERVAL_TIME = 5000;
 
 	private findUsernameFromStatusIndicator(el?: Element | null): string | null {
 		const container = el?.parentElement?.parentElement?.parentElement;
@@ -111,6 +115,7 @@ export default class ChattersModule extends TwitchModule {
 		this.requestUpdate();
 		if (this.updateInterval) clearInterval(this.updateInterval);
 		this.updateInterval = setInterval(() => this.requestUpdate(), ChattersModule.UPDATE_INTERVAL_TIME);
+		this.startChannelDiscovery();
 
 		wrappers.forEach((element) => {
 			render(
@@ -166,42 +171,50 @@ export default class ChattersModule extends TwitchModule {
 	}
 
 	private async refreshChatters(loginsToUpdate: string[] = []) {
-		await this.commonUtils().waitFor(
-			() => this.getLoginsOrIsAllowedPage(),
-			async (channelList) => {
-				const uniqueLogins = this.getUniqueLogins(channelList === true ? undefined : channelList);
-				this.logger.debug("Refreshing chatters for", uniqueLogins);
+		if (this.refreshingChatters) return false;
+		this.refreshingChatters = true;
 
-				const logins =
-					loginsToUpdate.length > 0 ? uniqueLogins.filter((login) => loginsToUpdate.includes(login)) : uniqueLogins;
+		try {
+			return await this.commonUtils().waitFor(
+				() => this.getLoginsOrIsAllowedPage(),
+				async (channelList) => {
+					const uniqueLogins = this.getUniqueLogins(channelList === true ? undefined : channelList);
+					this.logger.debug("Refreshing chatters for", uniqueLogins);
 
-				await Promise.all(
-					logins.map(async (login) => {
-						try {
-							const { data } = await this.twitchApi().gql<ChattersResponse>(ChattersQuery, {
-								name: login.toLowerCase(),
-							});
-							const counter = this.getOrCreateCounter(login, data.channel.chatters.count);
-							counter.value = data.channel.chatters.count;
-							this.logger.info(`Refreshed chatters for ${login}`, counter.value);
-						} catch (error) {
-							this.logger.warn(`Failed to fetch chatters for ${login}`, error);
+					const logins =
+						loginsToUpdate.length > 0 ? uniqueLogins.filter((login) => loginsToUpdate.includes(login)) : uniqueLogins;
+
+					await Promise.all(
+						logins.map(async (login) => {
+							try {
+								const { data } = await this.twitchApi().gql<ChattersResponse>(ChattersQuery, {
+									name: login.toLowerCase(),
+								});
+								const counter = this.getOrCreateCounter(login, data.channel.chatters.count);
+								counter.value = data.channel.chatters.count;
+								this.logger.info(`Refreshed chatters for ${login}`, counter.value);
+							} catch (error) {
+								this.logger.warn(`Failed to fetch chatters for ${login}`, error);
+							}
+						}),
+					);
+
+					for (const activeLogin of Object.keys(this.chattersCounters)) {
+						if (!uniqueLogins.includes(activeLogin)) {
+							delete this.chattersCounters[activeLogin];
 						}
-					}),
-				);
-
-				for (const activeLogin of Object.keys(this.chattersCounters)) {
-					if (!uniqueLogins.includes(activeLogin)) {
-						delete this.chattersCounters[activeLogin];
 					}
-				}
 
-				this.updateTotalChattersCounter();
-				this.lastUpdatedAt = Date.now();
-				return true;
-			},
-			{ delay: 1000, maxRetries: 5, initialDelay: 30 },
-		);
+					this.updateTotalChattersCounter();
+					this.lastKnownLogins = new Set(uniqueLogins);
+					this.lastUpdatedAt = Date.now();
+					return true;
+				},
+				{ delay: 1000, maxRetries: 5, initialDelay: 30 },
+			);
+		} finally {
+			this.refreshingChatters = false;
+		}
 	}
 
 	private getLoginsOrIsAllowedPage() {
@@ -212,13 +225,50 @@ export default class ChattersModule extends TwitchModule {
 
 	private getLogins(): string[] | undefined {
 		const streamInfo = this.twitchUtils().getStreamInfo();
-		if (!streamInfo) return;
-		const organizerLogin = streamInfo?.channelLogin;
-		const costreamerLogins = streamInfo?.costreamDetails?.topCostreamers.map((streamer) => streamer.login) ?? [];
-		const guestStarLogins = streamInfo?.guestStarGuests.map((guest) => guest.user.login) ?? [];
-		const allLoginsWithDuplicates = [organizerLogin, ...costreamerLogins, ...guestStarLogins];
+		const sharedChatLogins = [...(this.twitchUtils().getChatInfo()?.props.sharedChatDataByChannelID.values() ?? [])]
+			.filter((channel) => channel.status === "ACTIVE")
+			.map((channel) => channel.login);
+		const streamLogins = streamInfo
+			? [
+					streamInfo.channelLogin,
+					...(streamInfo.costreamDetails?.topCostreamers.map((streamer) => streamer.login) ?? []),
+					...(streamInfo.guestStarGuests ?? []).map((guest) => guest.user.login),
+					...(streamInfo.guestList ?? []).map((guest) => guest.user.login),
+				]
+			: [];
+		const allLoginsWithDuplicates = [...streamLogins, ...sharedChatLogins];
 		const validLogins = allLoginsWithDuplicates.filter((login): login is string => login != null);
-		return Array.from(new Set(validLogins));
+		const uniqueLogins = Array.from(new Set(validLogins));
+		return uniqueLogins.length > 0 ? uniqueLogins : undefined;
+	}
+
+	private startChannelDiscovery() {
+		if (this.channelDiscoveryTimer) return;
+
+		let burstChecksLeft = 4;
+		const check = async () => {
+			await this.refreshIfChannelsChanged();
+			const isBurst = burstChecksLeft > 0;
+			burstChecksLeft = Math.max(0, burstChecksLeft - 1);
+			this.channelDiscoveryTimer = setTimeout(check, isBurst ? 1000 : ChattersModule.CHANNEL_DISCOVERY_INTERVAL_TIME);
+		};
+
+		void check();
+	}
+
+	private async refreshIfChannelsChanged() {
+		const channelList = this.getLoginsOrIsAllowedPage();
+		if (channelList === undefined) return;
+
+		const uniqueLogins = this.getUniqueLogins(channelList === true ? undefined : channelList);
+		if (
+			uniqueLogins.length === this.lastKnownLogins.size &&
+			uniqueLogins.every((login) => this.lastKnownLogins.has(login))
+		) {
+			return;
+		}
+
+		await this.refreshChatters(uniqueLogins);
 	}
 
 	private updateTotalChattersCounter() {
@@ -260,6 +310,7 @@ export default class ChattersModule extends TwitchModule {
 
 	private async reloadCounters() {
 		if (!(await this.isModuleEnabled())) return;
+		this.lastKnownLogins.clear();
 		Object.values(this.chattersCounters).forEach((counter) => {
 			counter.value = ChattersModule.LOADING_VALUE;
 		});

--- a/src/platforms/twitch/twitch.utils.ts
+++ b/src/platforms/twitch/twitch.utils.ts
@@ -322,7 +322,8 @@ export default class TwitchUtils {
 			this.reactUtils.getReactInstance(document.querySelector("#live-channel-stream-information")),
 			(n) =>
 				(n?.pendingProps?.costreamDetails !== undefined && n?.pendingProps?.costreamViewCount !== undefined) ||
-				n?.pendingProps?.guestStarGuests !== undefined,
+				n?.pendingProps?.guestStarGuests !== undefined ||
+				n?.pendingProps?.guestList !== undefined,
 			100,
 		)?.pendingProps;
 		if (!props) return;

--- a/src/types/platforms/twitch/twitch.utils.types.ts
+++ b/src/types/platforms/twitch/twitch.utils.types.ts
@@ -377,7 +377,8 @@ export interface StreamInfoTwitchStreamData {
 	liveSince: string;
 	viewCount: number;
 	collabViewCount: number | null;
-	guestStarGuests: StreamInfoGuestStarGuest[];
+	guestStarGuests?: StreamInfoGuestStarGuest[];
+	guestList?: StreamInfoGuestStarGuest[];
 	guestStarSessionID: string | null;
 	guestStarHostID: string | null;
 	broadcastID: string;


### PR DESCRIPTION
## Summary
Improve Twitch shared-chat chatter discovery without requiring hover.

## Changes
- Read active channels from Twitch guestList and sharedChatDataByChannelID.
- Check immediately, four more times at one-second intervals, then every five seconds.
- Refresh chatter counts only when the detected channel set changes.
- Keep the regular 30-second counter refresh and prevent overlapping refreshes.

## Testing
- bun run typecheck
- npx @biomejs/biome check src/
- bun test: 18 tests passed