### PR TITLE
fix(twitch): complete light mode styling

### DIFF
--- a/src/platforms/twitch/modules/chatters/chatters.module.tsx
+++ b/src/platforms/twitch/modules/chatters/chatters.module.tsx
@@ -325,6 +325,10 @@ const Wrapper = styled.span`
 	font-weight: 600 !important;
 	white-space: nowrap;
 
+	html.tw-root--theme-light & {
+		color: #b4232a;
+	}
+
 	&:hover {
 		opacity: 0.75;
 		cursor: pointer;
@@ -336,8 +340,13 @@ const StreamManagerWrapper = styled(Wrapper)`
 	font-size: 11px;
 	padding: 3px;
 	border-radius: 4px;
-color: #000;
+	color: #000;
 	margin-left: 8px;
+
+	html.tw-root--theme-light & {
+		background-color: #d64a4a;
+		color: #ffffff;
+	}
 `;
 
 const formatChatters = (chatters: number) =>

--- a/src/platforms/twitch/modules/settings-button/settings-button.module.tsx
+++ b/src/platforms/twitch/modules/settings-button/settings-button.module.tsx
@@ -65,6 +65,14 @@ const StyledSettingsButton = styled.button`
   padding: 0;
   color: inherit;
 
+  img {
+    filter: none;
+  }
+
+  html.tw-root--theme-light & img {
+    filter: brightness(0);
+  }
+
   &:hover {
     background: var(--color-background-button-text-hover);
   }

--- a/src/shared/components/channel-section/channel-section.component.tsx
+++ b/src/shared/components/channel-section/channel-section.component.tsx
@@ -88,12 +88,32 @@ function getActionText(value: Signal<string> | string) {
 }
 
 const Container = styled.div`
-	background: rgba(25, 25, 28, 0.95);
+	--channel-background: rgba(25, 25, 28, 0.95);
+	--channel-header-background: rgba(30, 30, 40, 0.6);
+	--channel-border: rgba(255, 255, 255, 0.05);
+	--channel-title: #ffffff;
+	--channel-text: #b8b8b8;
+	--channel-link-background: rgba(40, 40, 50, 0.6);
+	--channel-action-background: rgba(255, 255, 255, 0.08);
+	--channel-action-text: #ffffff;
+
+	html.tw-root--theme-light & {
+		--channel-background: #ffffff;
+		--channel-header-background: #f1f1f2;
+		--channel-border: #dedee3;
+		--channel-title: #0e0e10;
+		--channel-text: #53535f;
+		--channel-link-background: #efeff1;
+		--channel-action-background: rgba(0, 0, 0, 0.06);
+		--channel-action-text: #0e0e10;
+	}
+
+	background: var(--channel-background);
 	border-radius: 8px;
 	overflow: hidden;
 	margin: 16px 0;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-	border: 1px solid rgba(255, 255, 255, 0.05);
+	border: 1px solid var(--channel-border);
 	transition: all 0.2s ease;
 
 	&:hover {
@@ -107,7 +127,7 @@ const Header = styled.div`
 	align-items: center;
 	justify-content: space-between;
 	padding: 12px 16px;
-	background: rgba(30, 30, 40, 0.6);
+	background: var(--channel-header-background);
 `;
 
 const ChannelInfo = styled.div`
@@ -139,12 +159,12 @@ const ChannelNameRow = styled.div`
 
 const ChannelName = styled.div`
 	font-weight: 600;
-	color: #ffffff;
+	color: var(--channel-title);
 	font-size: 14px;
 `;
 
 const RowText = styled.div`
-	color: #b8b8b8;
+	color: var(--channel-text);
 	font-size: 12px;
 	display: flex;
 	align-items: center;
@@ -163,9 +183,9 @@ const LinkItem = styled.a`
 	display: flex;
 	align-items: center;
 	padding: 8px 12px;
-	background: rgba(40, 40, 50, 0.6);
+	background: var(--channel-link-background);
 	border-radius: 6px;
-	color: #e0e0e0;
+	color: var(--channel-title);
 	text-decoration: none;
 	transition: all 0.2s;
 
@@ -200,8 +220,8 @@ const ActionButton = styled.button`
 	height: 24px;
 	border: none;
 	border-radius: 4px;
-	background: rgba(255, 255, 255, 0.08);
-	color: #ffffff;
+	background: var(--channel-action-background);
+	color: var(--channel-action-text);
 	cursor: pointer;
 	padding: 0;
 	font-size: 14px;
@@ -209,5 +229,6 @@ const ActionButton = styled.button`
 
 	&:hover {
 		background: rgba(145, 71, 255, 0.3);
+		color: #ffffff;
 	}
 `;

--- a/src/shared/components/export-import/export-import.component.tsx
+++ b/src/shared/components/export-import/export-import.component.tsx
@@ -13,8 +13,8 @@ const Container = styled.div`
 	justify-content: space-between;
 	gap: 24px;
 	width: 100%;
-	background: #111111;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-surface);
+	border: 1px solid var(--settings-border);
 	border-radius: 12px;
 	padding: 16px;
 `;
@@ -28,13 +28,13 @@ const InfoSection = styled.div`
 `;
 
 const InfoTitle = styled.span`
-	color: #f0f0f0;
+	color: var(--settings-text-strong);
 	font-size: 13px;
 	font-weight: 500;
 `;
 
 const InfoDescription = styled.span`
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 	line-height: 1.5;
 `;
@@ -52,9 +52,9 @@ const ButtonGroup = styled.div`
 `;
 
 const ActionButton = styled.button`
-	background: #1a1a1a;
-	border: 1px solid #262626;
-	color: #e5e5e5;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
+	color: var(--settings-text);
 	padding: 8px 18px;
 	border-radius: 8px;
 	font-size: 12px;
@@ -70,7 +70,7 @@ const ActionButton = styled.button`
 	&:hover:not(:disabled) {
 		border-color: #9147ff;
 		color: #9147ff;
-		background: #171717;
+		background: var(--settings-control-hover);
 	}
 
 	&:disabled {
@@ -95,7 +95,7 @@ const StatusOverlay = styled.div<{ type: "success" | "error" }>`
 	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
 	animation: slideIn 0.3s ease;
 
-	background: #121212;
+	background: var(--settings-surface-raised);
 
 	color: ${(props) => (props.type === "success" ? "#66bb6a" : "#ff5252")};
 

--- a/src/shared/components/latency/latency.component.tsx
+++ b/src/shared/components/latency/latency.component.tsx
@@ -22,10 +22,18 @@ const LatencyWrapper = styled.div`
 	transition: all 0.2s ease;
 	user-select: none;
 
+	html.tw-root--theme-light & {
+		color: #0e0e10;
+	}
+
 	&:hover {
 		color: #ffffff;
 		cursor: pointer;
 		transform: translateY(-1px);
+	}
+
+	html.tw-root--theme-light &:hover {
+		color: #0e0e10;
 	}
 `;
 
@@ -42,6 +50,10 @@ const PlaybackRate = styled.span`
 	font-size: 11px;
 	font-weight: 600;
 	color: rgba(222, 222, 227, 0.5);
+
+	html.tw-root--theme-light & {
+		color: rgba(14, 14, 16, 0.55);
+	}
 `;
 
 export function LatencyComponent({ click, latencyCounter, isLive, playbackRate }: LatencyComponentProps) {

--- a/src/shared/components/settings/about.component.tsx
+++ b/src/shared/components/settings/about.component.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const Container = styled.div`
 	padding: 0;
 	line-height: 1.6;
-	color: #ccc;
+	color: var(--settings-text);
 	width: 100%;
 	max-width: none;
 	display: flex;
@@ -14,9 +14,9 @@ const Container = styled.div`
 const Header = styled.div`
 	text-align: center;
 	padding: 28px 32px;
-	background: #111111;
+	background: var(--settings-surface);
 	border-radius: 12px;
-	border: 1px solid #1e1e1e;
+	border: 1px solid var(--settings-border);
 	position: relative;
 	overflow: hidden;
 
@@ -33,7 +33,7 @@ const Header = styled.div`
 `;
 
 const Title = styled.h1`
-	color: #ffffff;
+	color: var(--settings-text-primary);
 	margin: 0 0 8px 0;
 	font-size: 24px;
 	font-weight: 700;
@@ -43,7 +43,7 @@ const Title = styled.h1`
 const Subtitle = styled.p`
 	font-size: 12px;
 	margin: 0 0 16px 0;
-	color: #a5a5a5;
+	color: var(--settings-text-secondary);
 	position: relative;
 `;
 
@@ -60,15 +60,15 @@ const VersionBadge = styled.div`
 `;
 
 const Card = styled.div`
-	background: #111111;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-surface);
+	border: 1px solid var(--settings-border);
 	border-radius: 12px;
 	padding: 20px;
 `;
 
 const Disclosure = styled.details`
-	background: #111111;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-surface);
+	border: 1px solid var(--settings-border);
 	border-radius: 12px;
 	overflow: hidden;
 `;
@@ -95,7 +95,7 @@ const DisclosureTitle = styled.span`
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	color: #ffffff;
+	color: var(--settings-text-primary);
 	font-size: 15px;
 	font-weight: 600;
 	line-height: 1;
@@ -113,7 +113,7 @@ const DisclosureTitle = styled.span`
 const DisclosureHint = styled.span`
 	display: flex;
 	align-items: center;
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11px;
 	line-height: 1;
 	flex-shrink: 0;
@@ -131,9 +131,9 @@ const DisclosureHint = styled.span`
 `;
 
 const DisclosureContent = styled.div`
-	border-top: 1px solid #1e1e1e;
+	border-top: 1px solid var(--settings-border);
 	padding: 16px 20px 20px;
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 	line-height: 1.6;
 
@@ -151,7 +151,7 @@ const DisclosureContent = styled.div`
 `;
 
 const SectionTitle = styled.h2`
-	color: #ffffff;
+	color: var(--settings-text-primary);
 	margin: 0 0 6px 0;
 	font-size: 15px;
 	font-weight: 600;
@@ -170,14 +170,14 @@ const SectionTitle = styled.h2`
 
 const SubSectionTitle = styled.h3`
 	margin: 22px 0 12px 0;
-	color: #f0f0f0;
+	color: var(--settings-text-strong);
 	font-size: 12.5px;
 	font-weight: 600;
 `;
 
 const Description = styled.p`
 	margin: 0 0 18px;
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 `;
 
@@ -192,13 +192,13 @@ const ServiceList = styled.ul`
 
 const ServiceItem = styled.li`
 	padding: 14px;
-	background: #0d0d0d;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
 	border-radius: 8px;
 	transition: border-color 0.15s ease;
 
 	&:hover {
-		border-color: #2a2a2a;
+		border-color: var(--settings-control-border);
 	}
 
 	a {
@@ -210,7 +210,7 @@ const ServiceItem = styled.li`
 
 	p {
 		margin: 6px 0 0;
-		color: #7c7c7c;
+		color: var(--settings-text-muted);
 		font-size: 10px;
 	}
 `;
@@ -222,18 +222,18 @@ const ContributorGrid = styled.div`
 `;
 
 const ContributorTag = styled.div`
-	background: #0d0d0d;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
 	padding: 10px 14px;
 	border-radius: 8px;
 	font-size: 10.5px;
-	color: #cfcfcf;
+	color: var(--settings-text);
 	text-align: center;
 	transition: border-color 0.15s ease, color 0.15s ease;
 
 	&:hover {
 		border-color: rgba(145, 71, 255, 0.4);
-		color: #fff;
+		color: #9147ff;
 	}
 `;
 
@@ -245,21 +245,21 @@ const SocialLinksContainer = styled.div`
 `;
 
 const SocialLink = styled.a`
-	color: #e5e5e5;
+	color: var(--settings-text);
 	text-decoration: none;
 	display: flex;
 	align-items: center;
 	font-size: 11px;
 	font-weight: 500;
 	padding: 13px 16px;
-	background: #0d0d0d;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
 	border-radius: 8px;
 	transition: border-color 0.15s ease, color 0.15s ease;
 
 	&:hover {
 		border-color: rgba(145, 71, 255, 0.4);
-		color: #fff;
+		color: #9147ff;
 		text-decoration: none;
 	}
 `;
@@ -274,7 +274,7 @@ const IconImage = styled.img`
 
 const BugReportText = styled.p`
 	margin: 0;
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 `;
 

--- a/src/shared/components/settings/settings.component.tsx
+++ b/src/shared/components/settings/settings.component.tsx
@@ -10,13 +10,55 @@ import styled from "styled-components";
 const FONT = `"Inter", "Noto Sans Arabic", "Roobert", "Helvetica Neue", Helvetica, Arial, sans-serif`;
 
 const SettingsContainer = styled.div`
+	--settings-background: #0d0d0d;
+	--settings-surface: #111111;
+	--settings-surface-raised: #121212;
+	--settings-border: #1e1e1e;
+	--settings-divider: #1c1c1c;
+	--settings-divider-subtle: #1a1a1a;
+	--settings-control-background: #0d0d0d;
+	--settings-control-border: #262626;
+	--settings-control-hover: #1c1c1c;
+	--settings-toggle-background: #2a2a2a;
+	--settings-toggle-hover: #333333;
+	--settings-text-primary: #ffffff;
+	--settings-text-strong: #f0f0f0;
+	--settings-text: #e5e5e5;
+	--settings-text-secondary: #a5a5a5;
+	--settings-text-muted: #7c7c7c;
+	--settings-text-dim: #6a6a6a;
+	--settings-text-faint: #565656;
+	--settings-input-placeholder: #4f4f4f;
+
+	html.tw-root--theme-light & {
+		--settings-background: #f7f7f8;
+		--settings-surface: #ffffff;
+		--settings-surface-raised: #ffffff;
+		--settings-border: #dedee3;
+		--settings-divider: #dedee3;
+		--settings-divider-subtle: #e5e5e7;
+		--settings-control-background: #ffffff;
+		--settings-control-border: #cfcfd5;
+		--settings-control-hover: #e5e5e7;
+		--settings-toggle-background: #c4c4c9;
+		--settings-toggle-hover: #b5b5bb;
+		--settings-text-primary: #0e0e10;
+		--settings-text-strong: #18181b;
+		--settings-text: #2f2f35;
+		--settings-text-secondary: #53535f;
+		--settings-text-muted: #6e6e78;
+		--settings-text-dim: #6e6e78;
+		--settings-text-faint: #878791;
+		--settings-input-placeholder: #8f8f99;
+	}
+
 	display: flex;
 	flex-direction: column;
 	width: min(940px, 92vw);
 	height: min(640px, 86vh);
-	background-color: #0d0d0d;
+	background-color: var(--settings-background);
 	border-radius: 16px;
-	border: 1px solid #232323;
+	border: 1px solid var(--settings-border);
 	box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
 	position: relative;
 	overflow: hidden;
@@ -42,11 +84,11 @@ const Header = styled.header`
 	display: flex;
 	align-items: center;
 	padding: 0 16px;
-	color: white;
+	color: var(--settings-text-primary);
 	gap: 12px;
 	height: 60px;
 	flex-shrink: 0;
-	border-bottom: 1px solid #1c1c1c;
+	border-bottom: 1px solid var(--settings-divider);
 	position: relative;
 	z-index: 2;
 `;
@@ -65,8 +107,8 @@ const LogoContainer = styled.div`
 	justify-content: center;
 	align-items: center;
 	border-radius: 9px;
-	box-shadow: inset 0 1px 0 0 #333333;
-	background: linear-gradient(to bottom, #282728 5%, #1c1d1f 100%);
+	box-shadow: inset 0 1px 0 0 var(--settings-control-hover);
+	background: linear-gradient(to bottom, var(--settings-control-hover) 5%, var(--settings-divider) 100%);
 	flex-shrink: 0;
 `;
 
@@ -84,12 +126,12 @@ const BrandText = styled.div`
 const BrandName = styled.span`
 	font-size: 14px;
 	font-weight: 600;
-	color: #ffffff;
+	color: var(--settings-text-primary);
 `;
 
 const BrandMeta = styled.span`
 	font-size: 10px;
-	color: #6a6a6a;
+	color: var(--settings-text-dim);
 	text-transform: capitalize;
 `;
 
@@ -102,17 +144,17 @@ const SearchContainer = styled.div`
 	align-items: center;
 	gap: 8px;
 	width: 260px;
-	background: #141414;
-	border: 1px solid #232323;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
 	border-radius: 9px;
 	padding: 0 10px;
 	height: 34px;
-	color: #565656;
+	color: var(--settings-text-faint);
 	transition: border-color 0.15s ease, background 0.15s ease;
 
 	&:focus-within {
 		border-color: #9147ff;
-		background: #171717;
+		background: var(--settings-surface);
 		color: #9147ff;
 	}
 `;
@@ -122,7 +164,7 @@ const SearchInput = styled.input`
 	min-width: 0;
 	background: none;
 	border: none;
-	color: white;
+	color: var(--settings-text-primary);
 	font-family: ${FONT};
 	font-size: 12px;
 	padding: 0;
@@ -130,7 +172,7 @@ const SearchInput = styled.input`
 	height: 100%;
 
 	&::placeholder {
-		color: #565656;
+		color: var(--settings-input-placeholder);
 	}
 `;
 
@@ -138,7 +180,7 @@ const IconButton = styled.button`
 	background: none;
 	border: none;
 	cursor: pointer;
-	color: #6a6a6a;
+	color: var(--settings-text-dim);
 	padding: 0;
 	width: 22px;
 	height: 22px;
@@ -150,7 +192,7 @@ const IconButton = styled.button`
 	transition: color 0.15s ease, background 0.15s ease;
 
 	&:hover {
-		color: white;
+		color: var(--settings-text-primary);
 	}
 `;
 
@@ -159,8 +201,8 @@ const CloseButton = styled(IconButton)`
 	height: 30px;
 
 	&:hover {
-		background: #1e1e1e;
-		color: white;
+		background: var(--settings-control-hover);
+		color: var(--settings-text-primary);
 	}
 `;
 
@@ -175,7 +217,7 @@ const Body = styled.div`
 const Sidebar = styled.nav`
 	width: 194px;
 	flex-shrink: 0;
-	border-right: 1px solid #1c1c1c;
+	border-right: 1px solid var(--settings-divider);
 	display: flex;
 	flex-direction: column;
 	padding: 12px 10px;
@@ -197,7 +239,12 @@ const NavItem = styled.button<{ active: boolean; dimmed: boolean }>`
 	border-radius: 8px;
 	transition: background 0.15s ease, color 0.15s ease;
 	background: ${(props) => (props.active ? "rgba(145, 71, 255, 0.14)" : "transparent")};
-	color: ${(props) => (props.active ? "#ffffff" : props.dimmed ? "#4a4a4a" : "#a5a5a5")};
+	color: ${(props) =>
+		props.active
+			? "var(--settings-text-primary)"
+			: props.dimmed
+				? "var(--settings-text-dim)"
+				: "var(--settings-text-secondary)"};
 
 	svg {
 		flex-shrink: 0;
@@ -205,8 +252,8 @@ const NavItem = styled.button<{ active: boolean; dimmed: boolean }>`
 	}
 
 	&:hover {
-		background: ${(props) => (props.active ? "rgba(145, 71, 255, 0.18)" : "#161616")};
-		color: ${(props) => (props.active ? "#ffffff" : "#e5e5e5")};
+		background: ${(props) => (props.active ? "rgba(145, 71, 255, 0.18)" : "var(--settings-control-hover)")};
+		color: ${(props) => (props.active ? "var(--settings-text-primary)" : "var(--settings-text)")};
 	}
 `;
 
@@ -230,9 +277,9 @@ const NavCount = styled.span`
 const SidebarFooter = styled.div`
 	margin-top: auto;
 	padding: 12px 10px 2px;
-	border-top: 1px solid #1c1c1c;
+	border-top: 1px solid var(--settings-divider);
 	font-size: 10px;
-	color: #4a4a4a;
+	color: var(--settings-text-dim);
 	display: flex;
 	justify-content: space-between;
 	gap: 6px;
@@ -253,24 +300,24 @@ const Content = styled.div`
 	}
 
 	&::-webkit-scrollbar-thumb {
-		background: #232323;
+		background: var(--settings-border);
 		border-radius: 10px;
-		border: 3px solid #0d0d0d;
+		border: 3px solid var(--settings-background);
 	}
 
 	&::-webkit-scrollbar-thumb:hover {
-		background: #2f2f2f;
+		background: var(--settings-control-border);
 	}
 
 	scrollbar-width: thin;
-	scrollbar-color: #232323 transparent;
+	scrollbar-color: var(--settings-border) transparent;
 `;
 
 const SectionTitle = styled.h2`
 	margin: 0 0 14px;
 	font-size: 16px;
 	font-weight: 600;
-	color: #ffffff;
+	color: var(--settings-text-primary);
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -279,7 +326,7 @@ const SectionTitle = styled.h2`
 		content: "";
 		flex: 1;
 		height: 1px;
-		background: #1c1c1c;
+		background: var(--settings-divider);
 	}
 `;
 
@@ -290,8 +337,8 @@ const Section = styled.section`
 `;
 
 const Card = styled.div`
-	background: #111111;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-surface);
+	border: 1px solid var(--settings-border);
 	border-radius: 12px;
 	overflow: hidden;
 
@@ -320,7 +367,7 @@ const Row = styled.div<{ disabled: boolean; nested: boolean }>`
 	transition: opacity 0.15s ease;
 
 	& + & {
-		border-top: 1px solid #1a1a1a;
+		border-top: 1px solid var(--settings-divider-subtle);
 	}
 
 	${(props) =>
@@ -334,7 +381,7 @@ const Row = styled.div<{ disabled: boolean; nested: boolean }>`
 			bottom: 14px;
 			width: 2px;
 			border-radius: 2px;
-			background: #262626;
+			background: var(--settings-control-border);
 		}
 	`
 			: ""}
@@ -348,7 +395,7 @@ const RowInfo = styled.div`
 const RowTitle = styled.div`
 	font-size: 13px;
 	font-weight: 500;
-	color: #f0f0f0;
+	color: var(--settings-text-strong);
 	margin-bottom: 3px;
 	display: flex;
 	align-items: center;
@@ -356,7 +403,7 @@ const RowTitle = styled.div`
 `;
 
 const RowDescription = styled.div`
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 	line-height: 1.5;
 `;
@@ -387,11 +434,11 @@ const ToggleTrack = styled.label<{ checked: boolean }>`
 	flex-shrink: 0;
 	cursor: pointer;
 	border-radius: 24px;
-	background-color: ${(props) => (props.checked ? "#9147ff" : "#2a2a2a")};
+	background-color: ${(props) => (props.checked ? "#9147ff" : "var(--settings-toggle-background)")};
 	transition: background-color 0.2s ease;
 
 	&:hover {
-		background-color: ${(props) => (props.checked ? "#a06bff" : "#333333")};
+		background-color: ${(props) => (props.checked ? "#a06bff" : "var(--settings-toggle-hover)")};
 	}
 
 	&:has(input:focus-visible) {
@@ -422,9 +469,9 @@ const ToggleCircle = styled.span<{ checked: boolean }>`
 `;
 
 const TextInput = styled.input`
-	background: #0d0d0d;
-	border: 1px solid #262626;
-	color: white;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
+	color: var(--settings-text-primary);
 	font-family: ${FONT};
 	font-size: 12px;
 	border-radius: 8px;
@@ -434,7 +481,7 @@ const TextInput = styled.input`
 	transition: border-color 0.15s ease;
 
 	&::placeholder {
-		color: #4f4f4f;
+		color: var(--settings-input-placeholder);
 	}
 
 	&:focus {
@@ -462,7 +509,7 @@ const NumberInput = styled(TextInput)`
 
 const Unit = styled.span`
 	font-size: 11px;
-	color: #6a6a6a;
+	color: var(--settings-text-dim);
 	min-width: 18px;
 `;
 
@@ -478,7 +525,7 @@ const Slider = styled.input`
 	appearance: none;
 	height: 4px;
 	border-radius: 4px;
-	background: #262626;
+	background: var(--settings-control-border);
 	outline: none;
 	cursor: pointer;
 
@@ -508,15 +555,15 @@ const Slider = styled.input`
 
 const SliderValue = styled.span`
 	font-size: 11px;
-	color: #a5a5a5;
+	color: var(--settings-text-secondary);
 	min-width: 42px;
 	text-align: right;
 	font-variant-numeric: tabular-nums;
 `;
 
 const FileInputContainer = styled.div`
-	background: #0d0d0d;
-	border: 1px solid #262626;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
 	border-radius: 8px;
 	padding: 4px;
 	min-width: 220px;
@@ -526,7 +573,7 @@ const FileInputContainer = styled.div`
 	transition: border-color 0.15s ease;
 
 	&:hover {
-		border-color: #333333;
+		border-color: var(--settings-control-border);
 	}
 `;
 
@@ -536,7 +583,7 @@ const UploadTriggerLabel = styled.label`
 	justify-content: center;
 	gap: 8px;
 	width: 100%;
-	color: #e5e5e5;
+	color: var(--settings-text);
 	font-size: 12px;
 	font-weight: 500;
 	cursor: pointer;
@@ -549,7 +596,7 @@ const UploadTriggerLabel = styled.label`
 	}
 
 	&:hover {
-		background: #1c1c1c;
+		background: var(--settings-control-hover);
 	}
 `;
 
@@ -560,7 +607,7 @@ const FileStatus = styled.div`
 	flex: 1;
 	min-width: 0;
 	padding-left: 8px;
-	color: #ccc;
+	color: var(--settings-text);
 	font-size: 11px;
 
 	svg {
@@ -582,7 +629,7 @@ const HiddenFileInput = styled.input`
 const RemoveFileButton = styled.button`
 	background: transparent;
 	border: none;
-	color: #565656;
+	color: var(--settings-text-faint);
 	cursor: pointer;
 	height: 28px;
 	width: 28px;
@@ -610,11 +657,11 @@ const FileUploadError = styled.div`
 `;
 
 const Select = styled.select`
-	background: #0d0d0d;
+	background: var(--settings-control-background);
 	padding: 9px 11px;
 	border-radius: 8px;
-	color: #e5e5e5;
-	border: 1px solid #262626;
+	color: var(--settings-text);
+	border: 1px solid var(--settings-control-border);
 	font-family: ${FONT};
 	font-size: 12px;
 	cursor: pointer;
@@ -630,8 +677,8 @@ const RadioContainer = styled.div`
 	display: flex;
 	gap: 6px;
 	flex-wrap: wrap;
-	background: #0d0d0d;
-	border: 1px solid #262626;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
 	border-radius: 8px;
 	padding: 3px;
 `;
@@ -647,12 +694,12 @@ const RadioLabel = styled.label<{ checked: boolean }>`
 	padding: 7px 12px;
 	border-radius: 6px;
 	font-size: 12px;
-	color: ${(props) => (props.checked ? "white" : "#8a8a8a")};
+	color: ${(props) => (props.checked ? "var(--settings-text-primary)" : "var(--settings-text-muted)")};
 	cursor: pointer;
 	transition: background 0.15s ease, color 0.15s ease;
 
 	&:hover {
-		color: ${(props) => (props.checked ? "white" : "#e5e5e5")};
+		color: ${(props) => (props.checked ? "var(--settings-text-primary)" : "var(--settings-text)")};
 	}
 `;
 
@@ -676,7 +723,7 @@ const ArrayInput = styled(TextInput)`
 
 const ArrayEmpty = styled.div`
 	font-size: 11.5px;
-	color: #565656;
+	color: var(--settings-text-faint);
 	padding: 4px 0;
 `;
 
@@ -686,8 +733,8 @@ const GhostButton = styled.button`
 	justify-content: center;
 	gap: 6px;
 	background: transparent;
-	border: 1px dashed #2e2e2e;
-	color: #a5a5a5;
+	border: 1px dashed var(--settings-control-border);
+	color: var(--settings-text-secondary);
 	padding: 8px 12px;
 	border-radius: 8px;
 	cursor: pointer;
@@ -703,8 +750,8 @@ const GhostButton = styled.button`
 
 const RemoveButton = styled.button`
 	background: transparent;
-	border: 1px solid #262626;
-	color: #6a6a6a;
+	border: 1px solid var(--settings-control-border);
+	color: var(--settings-text-dim);
 	width: 32px;
 	height: 34px;
 	flex-shrink: 0;
@@ -728,9 +775,9 @@ const RefreshBar = styled.div`
 	gap: 10px;
 	flex-shrink: 0;
 	padding: 10px 16px;
-	border-top: 1px solid #1c1c1c;
+	border-top: 1px solid var(--settings-divider);
 	background: rgba(145, 71, 255, 0.06);
-	color: #cfc2e6;
+	color: var(--settings-text);
 	font-size: 12px;
 	position: relative;
 	z-index: 2;
@@ -763,18 +810,18 @@ const PrimaryButton = styled.button`
 `;
 
 const SecondaryButton = styled(PrimaryButton)`
-	background: #232323;
-	color: #ccc;
+	background: var(--settings-border);
+	color: var(--settings-text);
 
 	&:hover {
-		background: #2f2f2f;
+		background: var(--settings-control-border);
 	}
 `;
 
 const NoResults = styled.div`
 	padding: 60px 20px;
 	text-align: center;
-	color: #565656;
+	color: var(--settings-text-faint);
 	font-size: 13px;
 	display: flex;
 	flex-direction: column;
@@ -782,7 +829,7 @@ const NoResults = styled.div`
 	gap: 10px;
 
 	svg {
-		color: #2e2e2e;
+		color: var(--settings-control-border);
 	}
 `;
 
@@ -799,9 +846,9 @@ const ModalOverlay = styled.div`
 `;
 
 const ModalContent = styled.div`
-	background-color: #121212;
+	background-color: var(--settings-surface-raised);
 	border-radius: 14px;
-	border: 1px solid #262626;
+	border: 1px solid var(--settings-control-border);
 	font-family: ${FONT} !important;
 	padding: 22px;
 	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
@@ -810,14 +857,14 @@ const ModalContent = styled.div`
 `;
 
 const ModalHeader = styled.h3`
-	color: white;
+	color: var(--settings-text-primary);
 	margin: 0 0 10px;
 	font-size: 15px;
 	font-weight: 600;
 `;
 
 const ModalMessage = styled.p`
-	color: #a5a5a5;
+	color: var(--settings-text-secondary);
 	font-size: 12.5px;
 	margin: 0;
 	line-height: 1.6;

--- a/src/shared/components/watchtime-list/watchtime-list.component.tsx
+++ b/src/shared/components/watchtime-list/watchtime-list.component.tsx
@@ -7,10 +7,10 @@ import styled from "styled-components";
 
 const Container = styled.div`
 	line-height: 1.6;
-	color: #ccc;
+	color: var(--settings-text);
 	width: 100%;
-	background: #111111;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-surface);
+	border: 1px solid var(--settings-border);
 	border-radius: 12px;
 	overflow: hidden;
 `;
@@ -35,13 +35,13 @@ const TitleGroup = styled.div`
 `;
 
 const Title = styled.span`
-	color: #f0f0f0;
+	color: var(--settings-text-strong);
 	font-size: 13px;
 	font-weight: 500;
 `;
 
 const ActionText = styled.span`
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 	transition: color 0.15s ease;
 
@@ -51,7 +51,7 @@ const ActionText = styled.span`
 `;
 
 const Chevron = styled.span<{ $expanded: boolean }>`
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	flex-shrink: 0;
 	display: flex;
 	transition: transform 0.2s ease, color 0.15s ease;
@@ -70,9 +70,9 @@ const ExportSection = styled.div<{ $visible: boolean }>`
 `;
 
 const ExportButton = styled.button`
-	background: #1a1a1a;
-	border: 1px solid #262626;
-	color: #e5e5e5;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
+	color: var(--settings-text);
 	padding: 7px 14px;
 	border-radius: 8px;
 	font-size: 11px;
@@ -83,7 +83,7 @@ const ExportButton = styled.button`
 	&:hover:not(:disabled) {
 		border-color: #9147ff;
 		color: #9147ff;
-		background: #171717;
+		background: var(--settings-control-hover);
 	}
 
 	&:disabled {
@@ -98,8 +98,8 @@ const Content = styled.div<{ $visible: boolean }>`
 `;
 
 const TableContainer = styled.div`
-	background: #0d0d0d;
-	border: 1px solid #1e1e1e;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
 	border-radius: 10px;
 	overflow: hidden;
 `;
@@ -110,11 +110,11 @@ const Table = styled.table`
 `;
 
 const TableHeader = styled.thead`
-	background: #141414;
+	background: var(--settings-control-hover);
 `;
 
 const TableHeaderRow = styled.tr`
-	border-bottom: 1px solid #1e1e1e;
+	border-bottom: 1px solid var(--settings-border);
 `;
 
 const TableHeaderCell = styled.th`
@@ -135,7 +135,7 @@ const PositionHeaderCell = styled(TableHeaderCell)`
 const TableBody = styled.tbody``;
 
 const TableRow = styled.tr`
-	border-bottom: 1px solid #171717;
+	border-bottom: 1px solid var(--settings-divider-subtle);
 	transition: background 0.15s ease;
 
 	&:hover {
@@ -150,12 +150,12 @@ const TableRow = styled.tr`
 const TableCell = styled.td`
 	padding: 11px 16px;
 	font-size: 11.5px;
-	color: #cfcfcf;
+	color: var(--settings-text);
 `;
 
 const PositionCell = styled(TableCell)`
 	text-align: center;
-	color: #6a6a6a;
+	color: var(--settings-text-dim);
 	font-weight: 600;
 	width: 64px;
 `;
@@ -184,9 +184,9 @@ const PaginationSection = styled.div`
 `;
 
 const PageButton = styled.button`
-	background: #1a1a1a;
-	border: 1px solid #262626;
-	color: #e5e5e5;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
+	color: var(--settings-text);
 	padding: 7px 14px;
 	border-radius: 8px;
 	font-size: 11px;
@@ -197,7 +197,7 @@ const PageButton = styled.button`
 	&:hover:not(:disabled) {
 		border-color: #9147ff;
 		color: #9147ff;
-		background: #171717;
+		background: var(--settings-control-hover);
 	}
 
 	&:disabled {
@@ -207,13 +207,13 @@ const PageButton = styled.button`
 `;
 
 const PageInfo = styled.span`
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11px;
 `;
 
 const LoadingText = styled.div`
 	text-align: center;
-	color: #7c7c7c;
+	color: var(--settings-text-muted);
 	font-size: 11.5px;
 	padding: 24px;
 `;


### PR DESCRIPTION
## Summary
Fix remaining Twitch light mode contrast and dark-only UI styles.

## Changes
- Add theme-aware colors for settings, About, Data Backup, and Watchtime List.
- Fix invisible About acknowledgements and social link hover states.
- Adapt channel section, chatter counters, latency text, and settings icon to light mode.

## Testing
- bun run build
- bun run typecheck
- npx @biomejs/biome check src/
- Manual MCP verification on Twitch light mode