### PR TITLE
feat(diagnostics): add log export

### DIFF
--- a/src/platforms/kick/modules/channel-section/channel-section.module.tsx
+++ b/src/platforms/kick/modules/channel-section/channel-section.module.tsx
@@ -93,7 +93,7 @@ export default class ChannelSectionModule extends KickModule {
 		try {
 			this.watchtimeCounter.value = await this.getWatchTime(this.currentUsername.value);
 		} catch (error) {
-			console.error("Failed to fetch watch time:", error);
+			this.logger.error("Failed to fetch watch time:", error);
 		}
 	}
 

--- a/src/platforms/kick/modules/settings/settings.module.tsx
+++ b/src/platforms/kick/modules/settings/settings.module.tsx
@@ -270,7 +270,7 @@ export default class SettingsModule extends KickModule {
 				type: "text",
 				categoryId: CATEGORY.ABOUT,
 				content: () => {
-					return <EnhancerAboutComponent icons={brandIcons} />;
+					return <EnhancerAboutComponent icons={brandIcons} platform="kick" workerService={workerService} />;
 				},
 				hideInfo: true,
 			},

--- a/src/platforms/twitch/modules/channel-section/channel-section.module.tsx
+++ b/src/platforms/twitch/modules/channel-section/channel-section.module.tsx
@@ -163,7 +163,7 @@ export default class ChannelSectionModule extends TwitchModule {
 		try {
 			this.watchtimeCounter.value = await this.getWatchTime(this.currentLogin.value);
 		} catch (error) {
-			console.error("Failed to fetch watch time:", error);
+			this.logger.error("Failed to fetch watch time:", error);
 		}
 	}
 

--- a/src/platforms/twitch/modules/settings/settings.module.tsx
+++ b/src/platforms/twitch/modules/settings/settings.module.tsx
@@ -332,7 +332,7 @@ export default class SettingsModule extends TwitchModule {
 				type: "text",
 				categoryId: CATEGORY.ABOUT,
 				content: () => {
-					return <EnhancerAboutComponent icons={brandIcons} />;
+					return <EnhancerAboutComponent icons={brandIcons} platform="twitch" workerService={workerService} />;
 				},
 				hideInfo: true,
 			},

--- a/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
+++ b/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
@@ -6,21 +6,14 @@ import { useEffect, useState } from "preact/hooks";
 import styled from "styled-components";
 
 const Container = styled.div`
+	width: 100%;
+`;
+
+const Header = styled.div`
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: space-between;
 	gap: 24px;
-	width: 100%;
-	background: var(--settings-control-background);
-	border: 1px solid var(--settings-border);
-	border-radius: 10px;
-	padding: 14px;
-
-	@media (max-width: 620px) {
-		align-items: stretch;
-		flex-direction: column;
-		gap: 12px;
-	}
 `;
 
 const Info = styled.div`
@@ -36,28 +29,47 @@ const Title = styled.span`
 	font-weight: 500;
 `;
 
+const Heading = styled(Title)`
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.2;
+
+	&::before {
+		content: "";
+		width: 3px;
+		height: 16px;
+		background: #9147ff;
+		border-radius: 2px;
+	}
+`;
+
 const Description = styled.span`
+	display: block;
+	margin-top: 6px;
 	color: var(--settings-text-muted);
 	font-size: 11.5px;
 	line-height: 1.5;
 `;
 
 const Button = styled.button`
-	background: var(--settings-control-background);
-	border: 1px solid var(--settings-control-border);
-	color: var(--settings-text);
-	padding: 8px 18px;
+	background: #9147ff;
+	border: none;
+	color: white;
+	padding: 8px 16px;
 	border-radius: 8px;
 	font-size: 12px;
 	font-weight: 500;
 	cursor: pointer;
 	min-width: 132px;
 	flex-shrink: 0;
+	transition: background 0.15s ease, transform 0.15s ease;
 
 	&:hover:not(:disabled) {
-		border-color: #9147ff;
-		color: #9147ff;
-		background: var(--settings-control-hover);
+		background: #7f39e0;
+		transform: translateY(-1px);
 	}
 
 	&:disabled {
@@ -66,7 +78,7 @@ const Button = styled.button`
 	}
 
 	@media (max-width: 620px) {
-		width: 100%;
+		min-width: 118px;
 	}
 `;
 
@@ -155,13 +167,15 @@ export function DiagnosticLogsComponent({ platform, workerService }: DiagnosticL
 	return (
 		<div>
 			<Container>
-				<Info>
-					<Title>Diagnostic logs</Title>
-					<Description>Exports recent Enhancer logs from this tab and its background worker.</Description>
-				</Info>
-				<Button onClick={exportLogs} disabled={loading}>
-					{loading ? "Exporting..." : "Export logs"}
-				</Button>
+				<Header>
+					<Info>
+						<Heading>Diagnostics</Heading>
+						<Description>Exports recent Enhancer logs from this tab and its background worker.</Description>
+					</Info>
+					<Button onClick={exportLogs} disabled={loading}>
+						{loading ? "Exporting..." : "Export logs"}
+					</Button>
+				</Header>
 			</Container>
 			{status && <Status $error={status.error}>{status.message}</Status>}
 		</div>

--- a/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
+++ b/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
@@ -6,75 +6,30 @@ import { useEffect, useState } from "preact/hooks";
 import styled from "styled-components";
 
 const Container = styled.div`
-	width: 100%;
-`;
-
-const Header = styled.div`
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 20px;
-`;
-
-const Info = styled.div`
-	display: flex;
-	flex-direction: column;
-	gap: 3px;
-	flex: 1;
-	min-width: 0;
-`;
-
-const Title = styled.span`
-	color: var(--settings-text-strong);
-	font-size: 13px;
-	font-weight: 500;
-`;
-
-const Heading = styled(Title)`
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	font-size: 15px;
-	font-weight: 600;
-	line-height: 1.2;
-
-	&::before {
-		content: "";
-		width: 3px;
-		height: 16px;
-		background: #9147ff;
-		border-radius: 2px;
-	}
-`;
-
-const Description = styled.span`
-	display: block;
-	margin-top: 6px;
-	color: var(--settings-text-muted);
-	font-size: 11.5px;
-	line-height: 1.5;
+	width: auto;
+	flex-shrink: 0;
 `;
 
 const Button = styled.button`
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: var(--settings-control-background);
-	border: 1px solid var(--settings-border);
-	color: var(--settings-text);
-	padding: 13px 16px;
+	background: #0d0d0d;
+	border: 1px solid #1e1e1e;
+	color: #e5e5e5;
+	padding: 8px 14px;
 	border-radius: 8px;
 	font-size: 11px;
 	font-weight: 500;
 	cursor: pointer;
-	min-width: 132px;
+	min-width: 112px;
 	flex-shrink: 0;
 	transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
 
 	&:hover:not(:disabled) {
-		background: var(--settings-control-hover);
+		background: #0d0d0d;
 		border-color: rgba(145, 71, 255, 0.4);
-		color: #9147ff;
+		color: #fff;
 	}
 
 	&:focus-visible {
@@ -87,9 +42,6 @@ const Button = styled.button`
 		cursor: not-allowed;
 	}
 
-	@media (max-width: 620px) {
-		min-width: 118px;
-	}
 `;
 
 const Status = styled.div<{ $error: boolean }>`
@@ -177,15 +129,9 @@ export function DiagnosticLogsComponent({ platform, workerService }: DiagnosticL
 	return (
 		<div>
 			<Container>
-				<Header>
-					<Info>
-						<Heading>Diagnostics</Heading>
-						<Description>Exports recent Enhancer logs from this tab and its background worker.</Description>
-					</Info>
-					<Button onClick={exportLogs} disabled={loading}>
-						{loading ? "Exporting..." : "Export logs"}
-					</Button>
-				</Header>
+				<Button onClick={exportLogs} disabled={loading}>
+					{loading ? "Exporting..." : "Export logs"}
+				</Button>
 			</Container>
 			{status && <Status $error={status.error}>{status.message}</Status>}
 		</div>

--- a/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
+++ b/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
@@ -11,15 +11,16 @@ const Container = styled.div`
 
 const Header = styled.div`
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	justify-content: space-between;
-	gap: 24px;
+	gap: 20px;
 `;
 
 const Info = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: 3px;
+	flex: 1;
 	min-width: 0;
 `;
 
@@ -55,21 +56,30 @@ const Description = styled.span`
 `;
 
 const Button = styled.button`
-	background: #9147ff;
-	border: none;
-	color: white;
-	padding: 8px 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
+	color: var(--settings-text);
+	padding: 13px 16px;
 	border-radius: 8px;
-	font-size: 12px;
+	font-size: 11px;
 	font-weight: 500;
 	cursor: pointer;
 	min-width: 132px;
 	flex-shrink: 0;
-	transition: background 0.15s ease, transform 0.15s ease;
+	transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
 
 	&:hover:not(:disabled) {
-		background: #7f39e0;
-		transform: translateY(-1px);
+		background: var(--settings-control-hover);
+		border-color: rgba(145, 71, 255, 0.4);
+		color: #9147ff;
+	}
+
+	&:focus-visible {
+		outline: 2px solid #9147ff;
+		outline-offset: 2px;
 	}
 
 	&:disabled {

--- a/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
+++ b/src/shared/components/diagnostic-logs/diagnostic-logs.component.tsx
@@ -1,0 +1,169 @@
+import { Logger } from "$shared/logger/logger.ts";
+import type WorkerService from "$shared/worker/worker.service.ts";
+import type { LogEntry } from "$types/shared/logger.types.ts";
+import type { PlatformType } from "$types/shared/platform.types.ts";
+import { useEffect, useState } from "preact/hooks";
+import styled from "styled-components";
+
+const Container = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 24px;
+	width: 100%;
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-border);
+	border-radius: 10px;
+	padding: 14px;
+
+	@media (max-width: 620px) {
+		align-items: stretch;
+		flex-direction: column;
+		gap: 12px;
+	}
+`;
+
+const Info = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	min-width: 0;
+`;
+
+const Title = styled.span`
+	color: var(--settings-text-strong);
+	font-size: 13px;
+	font-weight: 500;
+`;
+
+const Description = styled.span`
+	color: var(--settings-text-muted);
+	font-size: 11.5px;
+	line-height: 1.5;
+`;
+
+const Button = styled.button`
+	background: var(--settings-control-background);
+	border: 1px solid var(--settings-control-border);
+	color: var(--settings-text);
+	padding: 8px 18px;
+	border-radius: 8px;
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	min-width: 132px;
+	flex-shrink: 0;
+
+	&:hover:not(:disabled) {
+		border-color: #9147ff;
+		color: #9147ff;
+		background: var(--settings-control-hover);
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	@media (max-width: 620px) {
+		width: 100%;
+	}
+`;
+
+const Status = styled.div<{ $error: boolean }>`
+	margin-top: 8px;
+	color: ${(props) => (props.$error ? "#ff5252" : "#66bb6a")};
+	font-size: 11px;
+`;
+
+interface DiagnosticLogsComponentProps {
+	platform: PlatformType;
+	workerService: WorkerService;
+}
+
+type ExportedLogs = {
+	meta: {
+		version: string;
+		platform: PlatformType;
+		hostname: string;
+		environment: string;
+		exportedAt: string;
+		sources: {
+			main: boolean;
+			bridge: boolean;
+			background: boolean;
+		};
+	};
+	logs: LogEntry[];
+};
+
+export function DiagnosticLogsComponent({ platform, workerService }: DiagnosticLogsComponentProps) {
+	const [loading, setLoading] = useState(false);
+	const [status, setStatus] = useState<{ message: string; error: boolean } | null>(null);
+
+	useEffect(() => {
+		if (!status) return;
+		const timer = setTimeout(() => setStatus(null), 5000);
+		return () => clearTimeout(timer);
+	}, [status]);
+
+	const exportLogs = async () => {
+		setLoading(true);
+		setStatus(null);
+		try {
+			const [backgroundResult, bridgeResult] = await Promise.allSettled([
+				workerService.send("getLogs"),
+				workerService.getBridgeLogs(),
+			]);
+			const backgroundLogs =
+				backgroundResult.status === "fulfilled" && Array.isArray(backgroundResult.value) ? backgroundResult.value : [];
+			const bridgeLogs = bridgeResult.status === "fulfilled" ? bridgeResult.value : [];
+			const logs = [...Logger.getLogs(), ...bridgeLogs, ...backgroundLogs].sort(
+				(first, second) => first.timestamp - second.timestamp,
+			);
+			const exportData: ExportedLogs = {
+				meta: {
+					version: window.enhancer.version,
+					platform,
+					hostname: window.location.hostname,
+					environment: window.enhancer.environment,
+					exportedAt: new Date().toISOString(),
+					sources: {
+						main: true,
+						bridge: bridgeResult.status === "fulfilled",
+						background: backgroundResult.status === "fulfilled" && backgroundResult.value !== null,
+					},
+				},
+				logs,
+			};
+
+			const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+			const link = document.createElement("a");
+			link.href = url;
+			link.download = `enhancer-logs-${platform}-${new Date().toISOString().split("T")[0]}.json`;
+			link.click();
+			URL.revokeObjectURL(url);
+			setStatus({ message: `Exported ${logs.length} log entries`, error: false });
+		} catch {
+			setStatus({ message: "Failed to export logs", error: true });
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<div>
+			<Container>
+				<Info>
+					<Title>Diagnostic logs</Title>
+					<Description>Exports recent Enhancer logs from this tab and its background worker.</Description>
+				</Info>
+				<Button onClick={exportLogs} disabled={loading}>
+					{loading ? "Exporting..." : "Export logs"}
+				</Button>
+			</Container>
+			{status && <Status $error={status.error}>{status.message}</Status>}
+		</div>
+	);
+}

--- a/src/shared/components/export-import/export-import.component.tsx
+++ b/src/shared/components/export-import/export-import.component.tsx
@@ -1,3 +1,4 @@
+import { Logger } from "$shared/logger/logger.ts";
 import type WorkerService from "$shared/worker/worker.service.ts";
 import type { CommonEvents } from "$types/platforms/common.events.ts";
 import type { PlatformSettings } from "$types/shared/worker/settings-worker.types.ts";
@@ -5,6 +6,8 @@ import type { PlatformType, WatchtimeRecord } from "$types/shared/worker/worker.
 import type { Emitter } from "nanoevents";
 import { useEffect, useState } from "preact/hooks";
 import styled from "styled-components";
+
+const logger = new Logger({ context: "export-import" });
 
 const Container = styled.div`
 	display: flex;
@@ -167,7 +170,7 @@ export function ExportImportComponent({ platform, workerService, emitter }: Expo
 			}
 			return allData;
 		} catch (error) {
-			console.error("Error fetching all watchtime data:", error);
+			logger.error("Error fetching all watchtime data:", error);
 			return allData;
 		}
 	};
@@ -199,7 +202,7 @@ export function ExportImportComponent({ platform, workerService, emitter }: Expo
 
 			showStatus(`Successfully exported ${platform} backup`, "success");
 		} catch (error) {
-			console.error("Export error:", error);
+			logger.error("Export error:", error);
 			showStatus("Failed to export data", "error");
 		} finally {
 			setLoading(false);
@@ -252,7 +255,7 @@ export function ExportImportComponent({ platform, workerService, emitter }: Expo
 					importedSettings = Object.keys(data.settings).length;
 					emitter.emit("extension:settings-refresh");
 				} catch (error) {
-					console.error("Failed to import settings:", error);
+					logger.error("Failed to import settings:", error);
 					showStatus("Failed to import settings", "error");
 					return;
 				}
@@ -280,7 +283,7 @@ export function ExportImportComponent({ platform, workerService, emitter }: Expo
 						importedWatchtime++;
 					} else {
 						failedWatchtime++;
-						console.error(`Failed to import record for ${recordsToImport[index].username}:`, result.reason);
+						logger.error(`Failed to import record for ${recordsToImport[index].username}:`, result.reason);
 					}
 				});
 			}
@@ -306,7 +309,7 @@ export function ExportImportComponent({ platform, workerService, emitter }: Expo
 			const type = failedWatchtime > 0 && importedWatchtime === 0 ? "error" : "success";
 			showStatus(message, type);
 		} catch (error) {
-			console.error("Import error:", error);
+			logger.error("Import error:", error);
 			showStatus("Failed to import data", "error");
 		} finally {
 			setLoading(false);

--- a/src/shared/components/settings/about.component.tsx
+++ b/src/shared/components/settings/about.component.tsx
@@ -385,8 +385,6 @@ export function EnhancerAboutComponent({ platform, workerService, icons }: Enhan
 			</Card>
 
 			<Card>
-				<SectionTitle>Diagnostics</SectionTitle>
-				<Description>Export recent logs when reporting a problem with Enhancer.</Description>
 				<DiagnosticLogsComponent platform={platform} workerService={workerService} />
 			</Card>
 

--- a/src/shared/components/settings/about.component.tsx
+++ b/src/shared/components/settings/about.component.tsx
@@ -293,6 +293,10 @@ const DiagnosticsInfo = styled.div`
 	min-width: 0;
 `;
 
+const DiagnosticsDescription = styled(Description)`
+	margin-bottom: 0;
+`;
+
 interface EnhancerAboutComponentProps {
 	platform: PlatformType;
 	workerService: WorkerService;
@@ -400,7 +404,7 @@ export function EnhancerAboutComponent({ platform, workerService, icons }: Enhan
 				<DiagnosticsRow>
 					<DiagnosticsInfo>
 						<SectionTitle>Diagnostics</SectionTitle>
-						<Description>Export recent logs when reporting a problem with Enhancer.</Description>
+						<DiagnosticsDescription>Export recent logs when reporting a problem with Enhancer.</DiagnosticsDescription>
 					</DiagnosticsInfo>
 					<DiagnosticLogsComponent platform={platform} workerService={workerService} />
 				</DiagnosticsRow>

--- a/src/shared/components/settings/about.component.tsx
+++ b/src/shared/components/settings/about.component.tsx
@@ -281,6 +281,18 @@ const BugReportText = styled.p`
 	font-size: 11.5px;
 `;
 
+const DiagnosticsRow = styled.div`
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 20px;
+`;
+
+const DiagnosticsInfo = styled.div`
+	flex: 1;
+	min-width: 0;
+`;
+
 interface EnhancerAboutComponentProps {
 	platform: PlatformType;
 	workerService: WorkerService;
@@ -385,7 +397,13 @@ export function EnhancerAboutComponent({ platform, workerService, icons }: Enhan
 			</Card>
 
 			<Card>
-				<DiagnosticLogsComponent platform={platform} workerService={workerService} />
+				<DiagnosticsRow>
+					<DiagnosticsInfo>
+						<SectionTitle>Diagnostics</SectionTitle>
+						<Description>Export recent logs when reporting a problem with Enhancer.</Description>
+					</DiagnosticsInfo>
+					<DiagnosticLogsComponent platform={platform} workerService={workerService} />
+				</DiagnosticsRow>
 			</Card>
 
 			<Card>

--- a/src/shared/components/settings/about.component.tsx
+++ b/src/shared/components/settings/about.component.tsx
@@ -1,3 +1,6 @@
+import { DiagnosticLogsComponent } from "$shared/components/diagnostic-logs/diagnostic-logs.component.tsx";
+import type WorkerService from "$shared/worker/worker.service.ts";
+import type { PlatformType } from "$types/shared/platform.types.ts";
 import styled from "styled-components";
 
 const Container = styled.div`
@@ -279,6 +282,8 @@ const BugReportText = styled.p`
 `;
 
 interface EnhancerAboutComponentProps {
+	platform: PlatformType;
+	workerService: WorkerService;
 	icons: {
 		website: string;
 		github: string;
@@ -287,7 +292,7 @@ interface EnhancerAboutComponentProps {
 	};
 }
 
-export function EnhancerAboutComponent({ icons }: EnhancerAboutComponentProps) {
+export function EnhancerAboutComponent({ platform, workerService, icons }: EnhancerAboutComponentProps) {
 	const externalServices = [
 		{
 			name: "api.enhancer.at",
@@ -377,6 +382,12 @@ export function EnhancerAboutComponent({ icons }: EnhancerAboutComponentProps) {
 						Discord
 					</SocialLink>
 				</SocialLinksContainer>
+			</Card>
+
+			<Card>
+				<SectionTitle>Diagnostics</SectionTitle>
+				<Description>Export recent logs when reporting a problem with Enhancer.</Description>
+				<DiagnosticLogsComponent platform={platform} workerService={workerService} />
 			</Card>
 
 			<Card>

--- a/src/shared/components/settings/settings.component.tsx
+++ b/src/shared/components/settings/settings.component.tsx
@@ -1,3 +1,4 @@
+import { Logger } from "$shared/logger/logger.ts";
 import type {
 	SettingCategory,
 	SettingDefinition,
@@ -6,6 +7,8 @@ import type {
 import type { JSX } from "preact";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import styled from "styled-components";
+
+const logger = new Logger({ context: "settings-ui" });
 
 const FONT = `"Inter", "Noto Sans Arabic", "Roobert", "Helvetica Neue", Helvetica, Arial, sans-serif`;
 
@@ -1331,7 +1334,7 @@ const Settings = <T,>({
 					const Component = setting.content;
 					return <Component />;
 				} catch (e) {
-					console.error("Enhancer Error when rendering component", e);
+					logger.error("Enhancer Error when rendering component", e);
 				}
 				return null;
 			}

--- a/src/shared/components/watchtime-list/watchtime-list.component.tsx
+++ b/src/shared/components/watchtime-list/watchtime-list.component.tsx
@@ -1,9 +1,12 @@
+import { Logger } from "$shared/logger/logger.ts";
 import type WorkerService from "$shared/worker/worker.service.ts";
 import type { CommonEvents } from "$types/platforms/common.events.ts";
 import type { PlatformType } from "$types/shared/worker/worker.types.ts";
 import type { Emitter } from "nanoevents";
 import { useEffect, useState } from "preact/hooks";
 import styled from "styled-components";
+
+const logger = new Logger({ context: "watchtime-list" });
 
 const Container = styled.div`
 	line-height: 1.6;
@@ -296,7 +299,7 @@ export function WatchtimeListComponent({
 			}
 			return allData;
 		} catch (error) {
-			console.error("Error fetching all watchtime data:", error);
+			logger.error("Error fetching all watchtime data:", error);
 			return allData;
 		}
 	};

--- a/src/shared/logger/logger.ts
+++ b/src/shared/logger/logger.ts
@@ -1,6 +1,7 @@
-import type { LogType, LoggerOptions } from "$types/shared/logger.types.ts";
+import type { LogEntry, LogType, LoggerOptions } from "$types/shared/logger.types.ts";
 
 export class Logger {
+	private static readonly MAX_ENTRIES = 500;
 	private static readonly BASE_PREFIX = "\x1B[1;38;2;145;71;255mEnhancer";
 	private static readonly LOG_TYPE_PREFIX: Record<LogType, string> = {
 		debug: "\x1B[38;2;102;204;255mDEBUG\x1B[0m",
@@ -8,19 +9,33 @@ export class Logger {
 		warn: "\x1B[38;2;255;215;102mWARN\x1B[0m",
 		error: "\x1B[38;2;255;99;99mERROR\x1B[0m",
 	};
+	private static readonly SENSITIVE_KEY = /authorization|cookie|token|password|secret|api[_-]?key|credential/i;
+	private static readonly SENSITIVE_HEADER = /((?:authorization|cookie|set-cookie)\s*:\s*)[^\r\n]*/gi;
+	private static readonly SENSITIVE_TEXT =
+		/(["']?(?:authorization|cookie|set-cookie|token|password|secret|api[_-]?key|credential)["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^,;}\s]*)/gi;
+	private static readonly SENSITIVE_QUERY =
+		/([?&](?:authorization|cookie|token|access_token|refresh_token|password|secret|api[_-]?key|credential)=)[^&#\s]*/gi;
+	private static readonly BEARER_TOKEN = /\bBearer\s+[^\s,;}]+/gi;
+	private static readonly MAX_DATA_LENGTH = 2000;
+	private static readonly MAX_ENTRY_LENGTH = 8192;
+	private static entries: LogEntry[] = [];
 	private readonly IS_DEVELOPMENT = __environment__ === "development";
 
 	private readonly prefix: string;
+	private readonly context?: string;
+	private readonly source: LogEntry["source"];
 
 	constructor(options: LoggerOptions = {}) {
-		const { context } = options;
+		const { context, source = "main" } = options;
+		this.context = context;
+		this.source = source;
 		this.prefix = context
 			? `${Logger.BASE_PREFIX} \x1B[38;2;128;128;128m${context}\x1B[0m`
 			: `${Logger.BASE_PREFIX}\x1B[0m`;
 	}
 
 	debug(...data: any[]): void {
-		if (this.IS_DEVELOPMENT) this.sendLog("debug", ...data);
+		this.sendLog("debug", ...data);
 	}
 
 	info(...data: any[]): void {
@@ -36,6 +51,79 @@ export class Logger {
 	}
 
 	private sendLog(logType: LogType, ...data: any[]): void {
-		console[logType](`${this.prefix} ${Logger.LOG_TYPE_PREFIX[logType]}`, ...data);
+		const normalizedData: string[] = [];
+		let entryLength = 0;
+		for (const value of data) {
+			const serialized = Logger.serialize(value);
+			const remaining = Logger.MAX_ENTRY_LENGTH - entryLength;
+			if (serialized.length > remaining) {
+				const suffix = "...[TRUNCATED]";
+				if (remaining > suffix.length) {
+					normalizedData.push(`${serialized.slice(0, remaining - suffix.length)}${suffix}`);
+				} else if (remaining > 0) {
+					normalizedData.push(suffix.slice(0, remaining));
+				}
+				break;
+			}
+			normalizedData.push(serialized);
+			entryLength += serialized.length;
+		}
+		Logger.entries.push({
+			timestamp: Date.now(),
+			level: logType,
+			context: this.context,
+			source: this.source,
+			data: normalizedData,
+		});
+		if (Logger.entries.length > Logger.MAX_ENTRIES) Logger.entries.shift();
+		if (logType !== "debug" || this.IS_DEVELOPMENT) {
+			console[logType](`${this.prefix} ${Logger.LOG_TYPE_PREFIX[logType]}`, ...normalizedData);
+		}
+	}
+
+	static getLogs(): LogEntry[] {
+		return Logger.entries.map((entry) => ({ ...entry, data: [...entry.data] }));
+	}
+
+	static clearLogs(): void {
+		Logger.entries = [];
+	}
+
+	private static serialize(value: unknown): string {
+		if (value instanceof Error) {
+			return Logger.sanitize(`${value.name}: ${value.message}${value.stack ? `\n${value.stack}` : ""}`);
+		}
+		if (typeof value === "string") return Logger.sanitize(value);
+		if (value === undefined) return "undefined";
+		if (value === null) return "null";
+		if (typeof value === "bigint") return `${value.toString()}n`;
+		if (typeof value !== "object") return Logger.sanitize(String(value));
+
+		const seen = new WeakSet<object>();
+		try {
+			const serialized = JSON.stringify(value, (key, nestedValue) => {
+				if (Logger.SENSITIVE_KEY.test(key)) return "[REDACTED]";
+				if (nestedValue instanceof Error) {
+					return { name: nestedValue.name, message: nestedValue.message, stack: nestedValue.stack };
+				}
+				if (nestedValue && typeof nestedValue === "object") {
+					if (seen.has(nestedValue)) return "[Circular]";
+					seen.add(nestedValue);
+				}
+				return nestedValue;
+			});
+			return Logger.sanitize(serialized ?? String(value));
+		} catch {
+			return Logger.sanitize(String(value));
+		}
+	}
+
+	private static sanitize(value: string): string {
+		return value
+			.replace(Logger.SENSITIVE_HEADER, "$1[REDACTED]")
+			.replace(Logger.BEARER_TOKEN, "Bearer [REDACTED]")
+			.replace(Logger.SENSITIVE_TEXT, "$1[REDACTED]")
+			.replace(Logger.SENSITIVE_QUERY, "$1[REDACTED]")
+			.slice(0, Logger.MAX_DATA_LENGTH);
 	}
 }

--- a/src/shared/storage/local-storage.ts
+++ b/src/shared/storage/local-storage.ts
@@ -1,6 +1,8 @@
+import { Logger } from "$shared/logger/logger.ts";
 import Storage from "$shared/storage/storage.ts";
 
 export default class LocalStorage<T extends Record<string, any>> extends Storage<T> {
+	private readonly logger = new Logger({ context: "local-storage" });
 	private cache: T | undefined;
 
 	async save<K extends keyof T>(key: K, value: T[K]): Promise<void> {
@@ -33,7 +35,7 @@ export default class LocalStorage<T extends Record<string, any>> extends Storage
 				this.cache = JSON.parse(rawStorage) as T;
 				return JSON.parse(JSON.stringify(this.cache)) as T;
 			} catch (error) {
-				console.error("Failed to parse storage data:", error);
+				this.logger.error("Failed to parse storage data:", error);
 				this.cache = {} as T;
 				return {} as T;
 			}
@@ -52,7 +54,7 @@ export default class LocalStorage<T extends Record<string, any>> extends Storage
 				this.cache = JSON.parse(rawStorage) as T;
 				return this.cache;
 			} catch (error) {
-				console.error("Failed to parse storage data:", error);
+				this.logger.error("Failed to parse storage data:", error);
 				this.cache = {} as T;
 				return {} as T;
 			}

--- a/src/shared/worker/database/database.ts
+++ b/src/shared/worker/database/database.ts
@@ -8,7 +8,7 @@ export abstract class Database {
 	protected abstract readonly dbVersion: number;
 
 	protected constructor(context: string) {
-		this.logger = new Logger({ context });
+		this.logger = new Logger({ context, source: "background" });
 	}
 
 	protected abstract onUpgrade(event: IDBVersionChangeEvent, db: IDBDatabase): void;

--- a/src/shared/worker/handler.registry.ts
+++ b/src/shared/worker/handler.registry.ts
@@ -2,6 +2,7 @@ import type { Logger } from "$shared/logger/logger.ts";
 import { EnhancerApiHandler } from "$shared/worker/enhancer-api/enhancer-api.handler.ts";
 import type { EnhancerApiService } from "$shared/worker/enhancer-api/enhancer-api.service.ts";
 import { AssetsFileHandler } from "$shared/worker/file/assets-file.handler.ts";
+import { GetLogsHandler } from "$shared/worker/logs/get-logs.handler.ts";
 import type { MessageHandler } from "$shared/worker/message.handler.ts";
 import { PingHandler } from "$shared/worker/ping/ping.handler.ts";
 import { GetSettingsHandler } from "$shared/worker/settings/get-settings.handler.ts";
@@ -29,6 +30,7 @@ export class HandlerRegistry {
 	}
 
 	private registerHandlers() {
+		this.handlers.set("getLogs", new GetLogsHandler(this.logger));
 		this.handlers.set("ping", new PingHandler(this.logger));
 		this.handlers.set("getAssetsFile", new AssetsFileHandler(this.logger));
 		this.handlers.set("addWatchtime", new AddWatchtimeHandler(this.logger, this.watchtimeAccumulator));

--- a/src/shared/worker/logs/get-logs.handler.ts
+++ b/src/shared/worker/logs/get-logs.handler.ts
@@ -1,0 +1,9 @@
+import { Logger } from "$shared/logger/logger.ts";
+import { MessageHandler } from "$shared/worker/message.handler.ts";
+import type { LogEntry } from "$types/shared/logger.types.ts";
+
+export class GetLogsHandler extends MessageHandler {
+	async handle(): Promise<LogEntry[]> {
+		return Logger.getLogs();
+	}
+}

--- a/src/shared/worker/watchtime/watchtime.accumulator.ts
+++ b/src/shared/worker/watchtime/watchtime.accumulator.ts
@@ -4,7 +4,7 @@ import { createWatchtimeId } from "$shared/worker/watchtime/watchtime.utils.ts";
 import type { PlatformType, WatchtimeRecord } from "$types/shared/worker/worker.types.ts";
 
 export class WatchtimeAccumulator {
-	private readonly logger = new Logger({ context: "watchtime-accumulator" });
+	private readonly logger = new Logger({ context: "watchtime-accumulator", source: "background" });
 	private watchedChannels = new Set<string>();
 	private updateInterval: ReturnType<typeof setInterval> | null = null;
 

--- a/src/shared/worker/worker.background.ts
+++ b/src/shared/worker/worker.background.ts
@@ -10,8 +10,8 @@ import type { PlatformSettings } from "$types/shared/worker/settings-worker.type
 import type { PlatformType } from "$types/shared/worker/worker.types.ts";
 
 export default class WorkerBackground {
-	private readonly logger = new Logger({ context: "background" });
-	private readonly enhancerApiLogger = new Logger({ context: "enhancer-api-worker" });
+	private readonly logger = new Logger({ context: "background", source: "background" });
+	private readonly enhancerApiLogger = new Logger({ context: "enhancer-api-worker", source: "background" });
 
 	private readonly settingsDatabase = new SettingsDatabase(
 		new Map<PlatformType, PlatformSettings>([

--- a/src/shared/worker/worker.bridge.ts
+++ b/src/shared/worker/worker.bridge.ts
@@ -1,3 +1,5 @@
+import { Logger } from "$shared/logger/logger.ts";
+import type { LogEntry } from "$types/shared/logger.types.ts";
 import type {
 	ExtensionMessageDetail,
 	ExtensionResponseDetail,
@@ -5,6 +7,7 @@ import type {
 } from "$types/shared/worker/worker.types.ts";
 
 export default class WorkerBridge {
+	private readonly logger = new Logger({ context: "worker-bridge", source: "bridge" });
 	private bridgeElement: HTMLElement | null = null;
 
 	start() {
@@ -40,6 +43,7 @@ export default class WorkerBridge {
 		if (!this.bridgeElement) return;
 		this.setupMessageForwarding();
 		this.setupBroadcastReceiving();
+		this.setupLogRetrieval();
 		this.bridgeElement.dispatchEvent(new CustomEvent("enhancer-bridge-ready"));
 		this.log("WorkerService bridge started!");
 	}
@@ -104,8 +108,23 @@ export default class WorkerBridge {
 		});
 	}
 
+	private setupLogRetrieval() {
+		if (!this.bridgeElement) return;
+		this.bridgeElement.addEventListener("enhancer-bridge-logs-request", ((event: CustomEvent<string>) => {
+			try {
+				const { requestId } = JSON.parse(event.detail) as { requestId: string };
+				const response = new CustomEvent<string>("enhancer-bridge-logs-response", {
+					detail: JSON.stringify({ requestId, logs: Logger.getLogs() satisfies LogEntry[] }),
+				});
+				this.bridgeElement?.dispatchEvent(response);
+			} catch (error) {
+				this.logger.error("Failed to provide bridge logs:", error);
+			}
+		}) as unknown as EventListener);
+	}
+
 	private log(...data: any[]) {
-		console.info("Enhancer worker-bridge", ...data);
+		this.logger.info(...data);
 	}
 }
 

--- a/src/shared/worker/worker.bridge.ts
+++ b/src/shared/worker/worker.bridge.ts
@@ -1,4 +1,3 @@
-import { Logger } from "$shared/logger/logger.ts";
 import type { LogEntry } from "$types/shared/logger.types.ts";
 import type {
 	ExtensionMessageDetail,
@@ -6,8 +5,101 @@ import type {
 	WorkerBroadcast,
 } from "$types/shared/worker/worker.types.ts";
 
+class BridgeLogger {
+	private static readonly MAX_ENTRIES = 500;
+	private static readonly MAX_DATA_LENGTH = 2000;
+	private static readonly MAX_ENTRY_LENGTH = 8192;
+	private static readonly SENSITIVE_KEY = /authorization|cookie|token|password|secret|api[_-]?key|credential/i;
+	private static readonly SENSITIVE_HEADER = /((?:authorization|cookie|set-cookie)\s*:\s*)[^\r\n]*/gi;
+	private static readonly SENSITIVE_TEXT =
+		/(["']?(?:authorization|cookie|set-cookie|token|password|secret|api[_-]?key|credential)["']?\s*[:=]\s*)("[^"]*"|'[^']*'|[^,;}\s]*)/gi;
+	private static readonly SENSITIVE_QUERY =
+		/([?&](?:authorization|cookie|token|access_token|refresh_token|password|secret|api[_-]?key|credential)=)[^&#\s]*/gi;
+	private static readonly BEARER_TOKEN = /\bBearer\s+[^\s,;}]+/gi;
+	private static entries: LogEntry[] = [];
+
+	constructor(private readonly context: string) {}
+
+	info(...data: unknown[]): void {
+		this.add("info", data);
+	}
+
+	error(...data: unknown[]): void {
+		this.add("error", data);
+	}
+
+	static getLogs(): LogEntry[] {
+		return BridgeLogger.entries.map((entry) => ({ ...entry, data: [...entry.data] }));
+	}
+
+	private add(level: LogEntry["level"], data: unknown[]): void {
+		const normalizedData: string[] = [];
+		let entryLength = 0;
+		for (const value of data) {
+			const serialized = this.serialize(value);
+			const remaining = BridgeLogger.MAX_ENTRY_LENGTH - entryLength;
+			if (serialized.length > remaining) {
+				const suffix = "...[TRUNCATED]";
+				if (remaining > suffix.length) {
+					normalizedData.push(`${serialized.slice(0, remaining - suffix.length)}${suffix}`);
+				} else if (remaining > 0) {
+					normalizedData.push(suffix.slice(0, remaining));
+				}
+				break;
+			}
+			normalizedData.push(serialized);
+			entryLength += serialized.length;
+		}
+		BridgeLogger.entries.push({
+			timestamp: Date.now(),
+			level,
+			context: this.context,
+			source: "bridge",
+			data: normalizedData,
+		});
+		if (BridgeLogger.entries.length > BridgeLogger.MAX_ENTRIES) BridgeLogger.entries.shift();
+		console[level](`Enhancer worker-bridge ${level.toUpperCase()}`, ...normalizedData);
+	}
+
+	private serialize(value: unknown): string {
+		if (value instanceof Error)
+			return this.sanitize(`${value.name}: ${value.message}${value.stack ? `\n${value.stack}` : ""}`);
+		if (typeof value === "string") return this.sanitize(value);
+		if (value === undefined) return "undefined";
+		if (value === null) return "null";
+		if (typeof value !== "object") return this.sanitize(String(value));
+
+		const seen = new WeakSet<object>();
+		try {
+			const serialized = JSON.stringify(value, (key, nestedValue) => {
+				if (BridgeLogger.SENSITIVE_KEY.test(key)) return "[REDACTED]";
+				if (nestedValue instanceof Error) {
+					return { name: nestedValue.name, message: nestedValue.message, stack: nestedValue.stack };
+				}
+				if (nestedValue && typeof nestedValue === "object") {
+					if (seen.has(nestedValue)) return "[Circular]";
+					seen.add(nestedValue);
+				}
+				return nestedValue;
+			});
+			return this.sanitize(serialized ?? String(value));
+		} catch {
+			return this.sanitize(String(value));
+		}
+	}
+
+	private sanitize(value: string): string {
+		return value
+			.replace(BridgeLogger.SENSITIVE_HEADER, "$1[REDACTED]")
+			.replace(BridgeLogger.BEARER_TOKEN, "Bearer [REDACTED]")
+			.replace(BridgeLogger.SENSITIVE_TEXT, "$1[REDACTED]")
+			.replace(BridgeLogger.SENSITIVE_QUERY, "$1[REDACTED]")
+			.slice(0, BridgeLogger.MAX_DATA_LENGTH);
+	}
+}
+
 export default class WorkerBridge {
-	private readonly logger = new Logger({ context: "worker-bridge", source: "bridge" });
+	private readonly logger = new BridgeLogger("worker-bridge");
 	private bridgeElement: HTMLElement | null = null;
 
 	start() {
@@ -114,7 +206,7 @@ export default class WorkerBridge {
 			try {
 				const { requestId } = JSON.parse(event.detail) as { requestId: string };
 				const response = new CustomEvent<string>("enhancer-bridge-logs-response", {
-					detail: JSON.stringify({ requestId, logs: Logger.getLogs() satisfies LogEntry[] }),
+					detail: JSON.stringify({ requestId, logs: BridgeLogger.getLogs() satisfies LogEntry[] }),
 				});
 				this.bridgeElement?.dispatchEvent(response);
 			} catch (error) {

--- a/src/shared/worker/worker.service.ts
+++ b/src/shared/worker/worker.service.ts
@@ -1,4 +1,5 @@
 import { Logger } from "$shared/logger/logger.ts";
+import type { LogEntry } from "$types/shared/logger.types.ts";
 import type {
 	CachedAggregateSeed,
 	EnhancerApiSeedRequestPayload,
@@ -164,6 +165,42 @@ export default class WorkerService {
 					resolve(null);
 				}
 			}, 10000);
+		});
+	}
+
+	getBridgeLogs(): Promise<LogEntry[]> {
+		return new Promise((resolve) => {
+			const requestId = crypto.randomUUID();
+			const timeout = { id: 0 };
+			const cleanup = () => {
+				clearTimeout(timeout.id);
+				this.element.removeEventListener("enhancer-bridge-logs-response", handleResponse);
+			};
+			const handleResponse = (event: Event) => {
+				try {
+					const detail = JSON.parse((event as CustomEvent<string>).detail) as {
+						requestId: string;
+						logs?: LogEntry[];
+					};
+					if (detail.requestId !== requestId) return;
+					cleanup();
+					resolve(Array.isArray(detail.logs) ? detail.logs : []);
+				} catch {
+					cleanup();
+					resolve([]);
+				}
+			};
+
+			this.element.addEventListener("enhancer-bridge-logs-response", handleResponse);
+			timeout.id = window.setTimeout(() => {
+				cleanup();
+				resolve([]);
+			}, 1000);
+			this.element.dispatchEvent(
+				new CustomEvent<string>("enhancer-bridge-logs-request", {
+					detail: JSON.stringify({ requestId }),
+				}),
+			);
 		});
 	}
 }

--- a/src/test/logger.test.ts
+++ b/src/test/logger.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, test } from "bun:test";
+import { Logger } from "$shared/logger/logger.ts";
+
+const originalEnvironment = (globalThis as typeof globalThis & { __environment__?: string }).__environment__;
+
+afterEach(() => {
+	Logger.clearLogs();
+	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: originalEnvironment });
+});
+
+test("removes credentials from exported log data", () => {
+	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: "production" });
+	const logger = new Logger({ context: "test" });
+
+	logger.error(
+		"Authorization: Bearer authorization-secret",
+		"Cookie: session=cookie-secret; refresh=refresh-secret",
+		"https://example.test/?access_token=query-secret",
+		{ token: "token-secret", nested: { authorization: "nested-secret" } },
+	);
+
+	const serialized = JSON.stringify(Logger.getLogs());
+
+	expect(serialized).not.toContain("authorization-secret");
+	expect(serialized).not.toContain("cookie-secret");
+	expect(serialized).not.toContain("refresh-secret");
+	expect(serialized).not.toContain("query-secret");
+	expect(serialized).not.toContain("token-secret");
+	expect(serialized).not.toContain("nested-secret");
+	expect(serialized).toContain("[REDACTED]");
+});
+
+test("limits the total size of one log entry", () => {
+	Object.defineProperty(globalThis, "__environment__", { configurable: true, value: "production" });
+	const logger = new Logger({ context: "test" });
+
+	logger.info(...Array.from({ length: 10 }, () => "x".repeat(2000)));
+
+	const [entry] = Logger.getLogs();
+	const entryLength = entry.data.reduce((total, value) => total + value.length, 0);
+
+	expect(entryLength).toBeLessThanOrEqual(8192);
+	expect(entry.data.at(-1)).toContain("TRUNCATED");
+});

--- a/src/types/shared/logger.types.ts
+++ b/src/types/shared/logger.types.ts
@@ -1,5 +1,16 @@
 export type LogType = "debug" | "info" | "warn" | "error";
 
+export type LogSource = "main" | "bridge" | "background";
+
+export type LogEntry = {
+	timestamp: number;
+	level: LogType;
+	context?: string;
+	source: LogSource;
+	data: string[];
+};
+
 export type LoggerOptions = {
 	context?: string;
+	source?: LogSource;
 };

--- a/src/types/shared/worker/worker.types.ts
+++ b/src/types/shared/worker/worker.types.ts
@@ -1,4 +1,5 @@
 import type { EnhancerStreamerWatchTimeData } from "$types/apis/enhancer.apis.ts";
+import type { LogEntry } from "$types/shared/logger.types.ts";
 import type { PlatformType } from "$types/shared/platform.types.ts";
 import type {
 	CachedAggregateSeed,
@@ -97,6 +98,10 @@ export type GetSettingsResponse = PlatformSettings;
 export type UpdateSettingsResponse = { success: true };
 
 export interface WorkerApiActions {
+	getLogs: {
+		payload: never;
+		response: LogEntry[];
+	};
 	ping: {
 		payload?: never;
 		response: PingResponse;


### PR DESCRIPTION
## Summary
Adds a user-facing diagnostic log export from the Enhancer settings.

## Changes
- Collects bounded, sanitized logs from main world, content bridge, and background worker.
- Adds an Export logs action under About > Diagnostics.
- Redacts authorization, cookie, token, password, secret, and credential values before console output and export.
- Caps each log entry at 8 KiB and keeps up to 500 entries per isolation.
- Adds logger sanitization and size-limit tests.

## Testing
- `bun test`
- `bun run typecheck`
- `npx @biomejs/biome check src/`
- `bun run build`